### PR TITLE
Implement "Fair Division Under Cardinality Constraints" (Biswas & Barman, 2018)

### DIFF
--- a/fairpyx/algorithms/__init__.py
+++ b/fairpyx/algorithms/__init__.py
@@ -14,6 +14,7 @@ from fairpyx.algorithms.course_match.main_course_match import course_match_algor
 from fairpyx.algorithms.santa_algorithm import santa_claus_main,is_threshold_feasible,solve_configuration_lp,classify_items,build_hypergraph,local_search_perfect_matching
 from fairpyx.algorithms.maximally_proportional import maximally_proportional_allocation
 from fairpyx.algorithms.qp_local_search import qp_max_min_allocation
+from fairpyx.algorithms.fair_division_under_cardinality_constraints import fair_division_under_cardinality_constraints
 
 
 # These algorithms are implemented but currently not working:

--- a/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
+++ b/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
@@ -7,9 +7,7 @@ Date : 2026-04
 
 import math
 import logging
-
-import networkz as nx
-
+import networkz as nz
 from fairpyx import Instance, AllocationBuilder
 
 logger = logging.getLogger(__name__)
@@ -19,17 +17,15 @@ logger = logging.getLogger(__name__)
 def fair_division_under_cardinality_constraints(
     alloc: AllocationBuilder,
     item_categories: dict,
-    agent_category_capacities: dict,
-    initial_agent_order: list,
+    category_capacities: dict,
+    initial_agent_order: list = None,
 ):
     """
-    Compute a feasible EF1 allocation under cardinality constraints (Algorithm 1,
-    Biswas & Barman 2018).
+    Compute a feasible EF1 allocation under cardinality constraints (Algorithm 1).
 
     All agents share the same per-category threshold k_h. Valuations are additive and
     may differ across agents. The algorithm guarantees EF1: for every pair of agents
-    (i, j) there exists some good g in j's bundle such that
-        v_i(A_i) >= v_i(A_j \\ {g}).
+    (i, j) there exists some good g in j's bundle such that v_i(A_i) >= v_i(A_j \\ {g}).
 
     Procedure:
       1. Validate all inputs via validate_fair_division_inputs.
@@ -45,13 +41,13 @@ def fair_division_under_cardinality_constraints(
     :param item_categories: a dictionary mapping each category name (str) to a list of
         item names. Every item in the instance must appear in exactly one category.
         Example: {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4', 'm5']}.
-    :param agent_category_capacities: a dictionary mapping each agent name (str) to a
-        dictionary of per-category integer capacities (k_h). All agents must have the same
-        k_h for each category. The sum of each agent's k_h values across all categories
-        should equal the agent_capacity passed to Instance.
-        Example: {'Agent1': {'c1': 1, 'c2': 2}, 'Agent2': {'c1': 1, 'c2': 2}}.
+    :param category_capacities: a dictionary mapping each category name (str) to a positive
+        integer threshold k_h — the maximum number of goods each agent may receive from that
+        category. All agents share the same k_h (required by the paper).
+        Example: {'c1': 1, 'c2': 2}.
     :param initial_agent_order: a list of agent names specifying the initial picking order
-        for the first category. Must contain each agent exactly once.
+        for the first category. Must contain each agent exactly once. If None (default),
+        agents are sorted lexicographically, giving a fully deterministic result.
 
     >>> # Example 1: basic — 2 agents, 2 categories, 1 good each, k_h=1
     >>> # Agent1 prefers m1 and m3; Agent2 prefers m2 and m4.
@@ -61,12 +57,16 @@ def fair_division_under_cardinality_constraints(
     ...     'Agent2': {'m1': 3, 'm2': 9, 'm3': 2, 'm4': 8},
     ... }
     >>> item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
-    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3', 'm4'], agent_capacities=sum_caps)
+    >>> category_capacities = {'c1': 1, 'c2': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['Agent1', 'Agent2'])
+    {'Agent1': ['m1', 'm3'], 'Agent2': ['m2', 'm4']}
+
+    >>> # Example 1b: same setup, no initial_agent_order — defaults to sorted(agents) = ['Agent1', 'Agent2']
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, category_capacities=category_capacities)
     {'Agent1': ['m1', 'm3'], 'Agent2': ['m2', 'm4']}
 
     >>> # Example 2: 3 agents, 2 categories of 3 goods each, k_h=1
@@ -78,15 +78,10 @@ def fair_division_under_cardinality_constraints(
     ...     'Agent3': {'m1': 6, 'm2': 3, 'm3': 9, 'm4': 5, 'm5': 2, 'm6': 8},
     ... }
     >>> item_categories = {'c1': ['m1', 'm2', 'm3'], 'c2': ['m4', 'm5', 'm6']}
-    >>> agent_category_capacities = {
-    ...     'Agent1': {'c1': 1, 'c2': 1},
-    ...     'Agent2': {'c1': 1, 'c2': 1},
-    ...     'Agent3': {'c1': 1, 'c2': 1},
-    ... }
-    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
-    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4','m5','m6'], agent_capacities=sum_caps)
+    >>> category_capacities = {'c1': 1, 'c2': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['Agent1', 'Agent2', 'Agent3'])
     {'Agent1': ['m1', 'm4'], 'Agent2': ['m2', 'm5'], 'Agent3': ['m3', 'm6']}
 
@@ -94,10 +89,10 @@ def fair_division_under_cardinality_constraints(
     >>> from fairpyx import Instance, divide
     >>> valuations = {'Alice': {'m1': 10, 'm2': 7, 'm3': 4}}
     >>> item_categories = {'c1': ['m1', 'm2', 'm3']}
-    >>> agent_category_capacities = {'Alice': {'c1': 3}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'], agent_capacities={'Alice': 3})
+    >>> category_capacities = {'c1': 3}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['Alice'])
     {'Alice': ['m1', 'm2', 'm3']}
 
@@ -105,10 +100,10 @@ def fair_division_under_cardinality_constraints(
     >>> from fairpyx import Instance, divide
     >>> valuations = {'A': {'x': 10, 'y': 5, 'z': 1}, 'B': {'x': 1, 'y': 5, 'z': 10}}
     >>> item_categories = {'c1': ['x', 'y', 'z']}
-    >>> agent_category_capacities = {'A': {'c1': 2}, 'B': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['x', 'y', 'z'], agent_capacities={'A': 2, 'B': 1})
+    >>> category_capacities = {'c1': 2}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['A', 'B'])
     {'A': ['x', 'y'], 'B': ['z']}
 
@@ -116,182 +111,263 @@ def fair_division_under_cardinality_constraints(
     >>> from fairpyx import Instance, divide
     >>> valuations = {'Agent1': {'m1': 8, 'm2': 5}, 'Agent2': {'m1': 5, 'm2': 8}}
     >>> item_categories = {'c1': ['m1'], 'c2': ['m2']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 2, 'Agent2': 2})
+    >>> category_capacities = {'c1': 1, 'c2': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['Agent1', 'Agent2'])
     {'Agent1': ['m1'], 'Agent2': ['m2']}
 
-    >>> # Example 6: boundary case — k_h = ceil(|C_h| / n), exactly the minimum feasible threshold
-    >>> # 3 agents, 3 goods in c1, k_h = ceil(3/3) = 1.
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {
-    ...     'A': {'g1': 9, 'g2': 6, 'g3': 3},
-    ...     'B': {'g1': 3, 'g2': 9, 'g3': 6},
-    ...     'C': {'g1': 6, 'g2': 3, 'g3': 9},
-    ... }
-    >>> item_categories = {'c1': ['g1', 'g2', 'g3']}
-    >>> agent_category_capacities = {'A': {'c1': 1}, 'B': {'c1': 1}, 'C': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['g1', 'g2', 'g3'], agent_capacities={'A': 1, 'B': 1, 'C': 1})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['A', 'B', 'C'])
-    {'A': ['g1'], 'B': ['g2'], 'C': ['g3']}
-
-    >>> # Example 7: asymmetric category sizes — c1 has 4 goods (k_h=2), c2 has 1 good (k_h=1)
+    >>> # Example 6: asymmetric category sizes — c1 has 4 goods (k_h=2), c2 has 1 good (k_h=1)
     >>> from fairpyx import Instance, divide
     >>> valuations = {
     ...     'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4, 'm5': 9},
     ...     'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10, 'm5': 7},
     ... }
     >>> item_categories = {'c1': ['m1', 'm2', 'm3', 'm4'], 'c2': ['m5']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 2, 'c2': 1}, 'Agent2': {'c1': 2, 'c2': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4','m5'],
-    ...                     agent_capacities={'Agent1': 3, 'Agent2': 3})
+    >>> category_capacities = {'c1': 2, 'c2': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
     ...        initial_agent_order=['Agent1', 'Agent2'])
     {'Agent1': ['m1', 'm2', 'm5'], 'Agent2': ['m3', 'm4']}
 
-    >>> # Example 8: EF1 property verification — for the result, no agent envies another
-    >>> # by more than the removal of one good from the other's bundle.
+    >>> # Example 7: minimal base case — 1 agent, 1 good, 1 category.
+    >>> # σ = ['a1'].  C1 round-robin: a1 picks g1 (only good). No envy possible.
+    >>> # Final allocation: {a1: [g1]}.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'a1': {'g1': 2}}
+    >>> item_categories = {'C1': ['g1']}
+    >>> category_capacities = {'C1': 1}
+    >>> instance = Instance(valuations=valuations)
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
+    ...        initial_agent_order=['a1'])
+    {'a1': ['g1']}
+
+    >>> # Example 8: 2 agents, 2 goods, 1 category, k_h=1 - full example explanation
+    >>> # σ = ['a1','a2'].
+    >>> # C1 round-robin:
+    >>> #   a1 picks best of {g1,g2}: values 2,3 → picks g2 (value 3).
+    >>> #   a2 picks best of {g1}:    value  1   → picks g1 (only remaining).
+    >>> # After C1: {a1:[g2], a2:[g1]}.
+    >>> #
+    >>> # Envy table (row = whose eyes, col = whose bundle):
+    >>> #              a1's bundle   a2's bundle
+    >>> #   a1 values:    3             2        → a1 does NOT envy a2 (3 >= 2).
+    >>> #   a2 values:    4             1        → a2 ENVIES a1 (4 > 1). Edge: a2→a1.
+    >>> #
+    >>> # Envy graph: a2→a1. No cycle. Topo sort: ['a2','a1'].
+    >>> # (Only one category, so updated σ is never used.)
+    >>> # Final allocation: {a1:[g2], a2:[g1]}.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'a1': {'g1': 2, 'g2': 3}, 'a2': {'g1': 1, 'g2': 4}}
+    >>> item_categories = {'C1': ['g1', 'g2']}
+    >>> category_capacities = {'C1': 1}
+    >>> instance = Instance(valuations=valuations)
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, category_capacities=category_capacities,
+    ...        initial_agent_order=['a1', 'a2'])
+    {'a1': ['g2'], 'a2': ['g1']}
+
+    >>> # Example 9: 2 agents, 6 goods, 2 categories, k_h=2 - full example explanation
+    >>> # Key feature: a2 envies a1 after C1, so the agent order REVERSES for C2,
+    >>> # giving a2 the first pick in the second category.
+    >>> #
+    >>> # σ = ['a1','a2'].
+    >>> # C1 round-robin (each agent picks at most k_h=2 goods):
+    >>> #   a1 picks best of {g1,g2,g3}: values 9,6,3 → g1 (value 9).
+    >>> #   a2 picks best of {g2,g3}:    values 7,8   → g3 (value 8).
+    >>> #   a1 picks best of {g2}:        value  6    → g2 (only remaining).
+    >>> # After C1: {a1:[g1,g2], a2:[g3]}.
+    >>> #
+    >>> # Envy table after C1:
+    >>> #              a1's bundle {g1,g2}   a2's bundle {g3}
+    >>> #   a1 values:     9+6=15                3         → a1 does NOT envy a2.
+    >>> #   a2 values:     4+7=11                8         → a2 ENVIES a1 (11>8). Edge: a2→a1.
+    >>> #
+    >>> # Envy graph: a2→a1. No cycle. Topo sort: a2 has no incoming edge → first.
+    >>> # σ updated to ['a2','a1'] for C2.
+    >>> #
+    >>> # C2 round-robin with σ=['a2','a1']:
+    >>> #   a2 picks best of {g4,g5,g6}: values 3,9,6 → g5 (value 9).
+    >>> #   a1 picks best of {g4,g6}:    values 8,2   → g4 (value 8).
+    >>> #   a2 picks best of {g6}:        value  6    → g6 (only remaining).
+    >>> # After C2: {a1:[g1,g2,g4], a2:[g3,g5,g6]}.
+    >>> #
+    >>> # Final envy table:
+    >>> #              a1's bundle {g1,g2,g4}   a2's bundle {g3,g5,g6}
+    >>> #   a1 values:    9+6+8=23                  3+5+2=10   → a1 does NOT envy a2.
+    >>> #   a2 values:    4+7+3=14                  8+9+6=23   → a2 does NOT envy a1.
+    >>> # No envy. Final allocation below.
     >>> from fairpyx import Instance, divide
     >>> valuations = {
-    ...     'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4},
-    ...     'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10},
+    ...     'a1': {'g1': 9, 'g2': 6, 'g3': 3, 'g4': 8, 'g5': 5, 'g6': 2},
+    ...     'a2': {'g1': 4, 'g2': 7, 'g3': 8, 'g4': 3, 'g5': 9, 'g6': 6},
     ... }
-    >>> item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
-    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
-    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4'], agent_capacities=sum_caps)
-    >>> result = divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...                 item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...                 initial_agent_order=['Agent1', 'Agent2'])
-    >>> # EF1 check for Agent1: there exists a good in Agent2's bundle whose removal ends the envy
-    >>> v1 = valuations['Agent1']
-    >>> val1_own   = sum(v1[g] for g in result['Agent1'])
-    >>> val1_other = sum(v1[g] for g in result['Agent2'])
-    >>> val1_own >= val1_other - max(v1[g] for g in result['Agent2'])
-    True
-
-    >>> # Example 9: invalid — negative valuation raises ValueError
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': -1, 'm2': 3}, 'Agent2': {'m1': 4, 'm2': 6}}
-    >>> item_categories = {'c1': ['m1', 'm2']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 1, 'Agent2': 1})
+    >>> item_categories = {'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']}
+    >>> category_capacities = {'C1': 2, 'C2': 2}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
+    ...        item_categories=item_categories, category_capacities=category_capacities,
+    ...        initial_agent_order=['a1', 'a2'])
+    {'a1': ['g1', 'g2', 'g4'], 'a2': ['g3', 'g5', 'g6']}
 
-    >>> # Example 10: invalid — k_h too small (k_h=1 < ceil(3/2)=2) raises ValueError
+    >>> # Example 10: 3 agents, 6 goods, 2 categories, k_h=1 - full example explanation
+    >>> # Key feature: after C2, the envy graph contains MULTIPLE OVERLAPPING CYCLES,
+    >>> # requiring eliminate_envy_cycles to resolve them iteratively.
+    >>> #
+    >>> # σ = ['a1','a2','a3'].
+    >>> # C1 round-robin:
+    >>> #   a1 picks best of {g1,g2,g3}: values 9,2,1 → g1.
+    >>> #   a2 picks best of {g2,g3}:    values 8,1   → g2.
+    >>> #   a3 picks best of {g3}:        value  5    → g3.
+    >>> # After C1: {a1:[g1], a2:[g2], a3:[g3]}.
+    >>> #
+    >>> # Envy table after C1:
+    >>> #              a1 {g1}   a2 {g2}   a3 {g3}
+    >>> #   a1 values:    9         2         1      → a1 does NOT envy anyone.
+    >>> #   a2 values:   10         8         1      → a2 ENVIES a1 (10>8). Edge: a2→a1.
+    >>> #   a3 values:   10         9         5      → a3 ENVIES a1 and a2. Edges: a3→a1, a3→a2.
+    >>> #
+    >>> # Envy graph: a2→a1, a3→a1, a3→a2. No cycle (DAG). Topo sort: ['a3','a2','a1'].
+    >>> # σ updated to ['a3','a2','a1'] for C2.
+    >>> #
+    >>> # C2 round-robin with σ=['a3','a2','a1']:
+    >>> #   a3 picks best of {g4,g5,g6}: values 8,1,7 → g4.
+    >>> #   a2 picks best of {g5,g6}:    values 1,0   → g5.
+    >>> #   a1 picks best of {g6}:        value  0    → g6.
+    >>> # After C2: {a1:[g1,g6], a2:[g2,g5], a3:[g3,g4]}.
+    >>> #
+    >>> # Envy table after C2:
+    >>> #              a1 {g1,g6}   a2 {g2,g5}   a3 {g3,g4}
+    >>> #   a1 values:  9+0=9       2+10=12       1+1=2      → a1 ENVIES a2. Edge: a1→a2.
+    >>> #   a2 values: 10+0=10      8+1=9        1+10=11     → a2 ENVIES a1 and a3. Edges: a2→a1, a2→a3.
+    >>> #   a3 values: 10+7=17      9+1=10        5+8=13     → a3 ENVIES a1. Edge: a3→a1.
+    >>> #
+    >>> # Envy graph edges: a1→a2, a2→a1, a2→a3, a3→a1.
+    >>> # This graph contains TWO overlapping simple cycles:
+    >>> #   - 2-cycle: a1↔a2        (edges a1→a2 and a2→a1)
+    >>> #   - 3-cycle: a1→a2→a3→a1 (edges a1→a2, a2→a3, a3→a1)
+    >>> #
+    >>> # Both elimination orderings are valid and both lead to the SAME final allocation
+    >>> # (verified by tracing both paths):
+    >>> #
+    >>> #   PATH A — eliminate 3-cycle first:
+    >>> #     Rotate: a1 ← a2's bundle, a2 ← a3's bundle, a3 ← a1's bundle.
+    >>> #     After rotation: {a1:[g2,g5], a2:[g3,g4], a3:[g1,g6]}.
+    >>> #     Verify: a1 own=12, a2's=9, a3's=9 → no envy.
+    >>> #             a2 own=11, a1's=9, a3's=10 → no envy.
+    >>> #             a3 own=17, a1's=10, a2's=13 → no envy. Done.
+    >>> #
+    >>> #   PATH B — eliminate 2-cycle first, then the resulting 2-cycle:
+    >>> #     Step 1: swap a1↔a2 → {a1:[g2,g5], a2:[g1,g6], a3:[g3,g4]}.
+    >>> #       New envy: a2 values a3's bundle at 11 > own 10, and a3 values a2's at 17 > own 13.
+    >>> #       New 2-cycle: a2↔a3.
+    >>> #     Step 2: swap a2↔a3 → {a1:[g2,g5], a2:[g3,g4], a3:[g1,g6]}.
+    >>> #       No remaining envy. Done.
+    >>> #
+    >>> # Both paths produce the SAME EF1 allocation for this specific instance — verified above.
+    >>> # Note: in general, different cycle orderings CAN lead to different valid EF1 allocations
+    >>> # (the paper guarantees EF1 for any order, but not uniqueness). For instances where the
+    >>> # two orderings diverge, use: assert result in [answer_path_A, answer_path_B].
     >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3, 'm3': 1}, 'Agent2': {'m1': 1, 'm2': 3, 'm3': 5}}
-    >>> item_categories = {'c1': ['m1', 'm2', 'm3']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'], agent_capacities={'Agent1': 1, 'Agent2': 1})
+    >>> valuations = {
+    ...     'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
+    ...     'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
+    ...     'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
+    ... }
+    >>> item_categories = {'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']}
+    >>> category_capacities = {'C1': 1, 'C2': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
+    ...        item_categories=item_categories, category_capacities=category_capacities,
+    ...        initial_agent_order=['a1', 'a2', 'a3'])
+    {'a1': ['g2', 'g5'], 'a2': ['g3', 'g4'], 'a3': ['g1', 'g6']}
 
-    >>> # Example 11: invalid — a good appears in two categories raises ValueError
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3}, 'Agent2': {'m1': 3, 'm2': 5}}
-    >>> item_categories_dup = {'c1': ['m1', 'm2'], 'c2': ['m1']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 2, 'Agent2': 2})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories_dup, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
+    >>> # Example 11: 4 agents, 26 goods, 4 categories (5/6/7/8 goods), k_h=2 - large example
+    >>> # This is the largest and most complex run example. Two order changes occur:
+    >>> #   - After C1: a3 envies a1 → σ becomes ['a3','a1','a2','a4'].
+    >>> #   - After C2: a2 envies a3 → σ becomes ['a2','a1','a3','a4'].
+    >>> #   - After C3: no envy     → σ remains  ['a1','a2','a3','a4'].
+    >>> #
+    >>> # C1=[g1..g5], C2=[g6..g11], C3=[g12..g18], C4=[g19..g26]; k_h=2 for all.
+    >>> #
+    >>> # C1 round-robin σ=['a1','a2','a3','a4'] (5 goods, 2 picks each — only 4 agents × 2=8 slots but only 5 goods):
+    >>> #   a1 picks g1 (9), a2 picks g2 (10), a3 picks g4 (9), a4 picks g3 (10), a1 picks g5 (6).
+    >>> # After C1: {a1:[g1,g5], a2:[g2], a3:[g4], a4:[g3]}.
+    >>> #
+    >>> # Envy table after C1 (values shown as agent_i sees bundle_j):
+    >>> #       a1{g1,g5}  a2{g2}  a3{g4}  a4{g3}
+    >>> #   a1:    15        4       1       8     → a1 does not envy anyone (15 is max).
+    >>> #   a2:     8       10       7       2     → a2 does not envy anyone (10 is max).
+    >>> #   a3:    10        1       9       5     → a3 ENVIES a1 (10>9). Edge: a3→a1.
+    >>> #   a4:     9        6       3      10     → a4 does not envy anyone (10 is max).
+    >>> # No cycle. Topo sort: a3 first. σ = ['a3','a1','a2','a4'].
+    >>> #
+    >>> # C2 round-robin σ=['a3','a1','a2','a4'] (6 goods):
+    >>> #   a3 picks g8 (10), a1 picks g7 (10), a2 picks g6 (9), a4 picks g9 (10),
+    >>> #   a3 picks g10 (7), a1 picks g11 (7).
+    >>> # After C2: {a1:[g1,g5,g7,g11], a2:[g2,g6], a3:[g4,g8,g10], a4:[g3,g9]}.
+    >>> #
+    >>> # Envy table after C2:
+    >>> #       a1{..}  a2{g2,g6}  a3{g4,g8,g10}  a4{g3,g9}
+    >>> #   a1:   32       6          5              13      → a1 does not envy (32 is max).
+    >>> #   a2:   11      19         21               6      → a2 ENVIES a3 (21>19). Edge: a2→a3.
+    >>> #   a3:   19       5         26              12      → a3 does not envy (26 is max).
+    >>> #   a4:   15      11          6              20      → a4 does not envy (20 is max).
+    >>> # No cycle. Topo sort: a2 first (only outgoing edge). σ = ['a2','a1','a3','a4'].
+    >>> #
+    >>> # C3 round-robin σ=['a2','a1','a3','a4'] (7 goods):
+    >>> #   a2 picks g15 (10), a1 picks g14 (9), a3 picks g17 (10), a4 picks g18 (10),
+    >>> #   a2 picks g13 (7), a1 picks g16 (8), a3 picks g12 (9).
+    >>> # After C3: {a1:[g1,g5,g7,g11,g14,g16], a2:[g2,g6,g15,g13], a3:[g4,g8,g10,g17,g12], a4:[g3,g9,g18]}.
+    >>> #
+    >>> # Envy table after C3: no agent envies another. σ remains ['a1','a2','a3','a4'].
+    >>> #
+    >>> # C4 round-robin σ=['a1','a2','a3','a4'] (8 goods):
+    >>> #   a1 picks g22 (10), a2 picks g25 (10), a3 picks g23 (9), a4 picks g24 (10),
+    >>> #   a1 picks g26 (8), a2 picks g21 (9), a3 picks g19 (8), a4 picks g20 (8).
+    >>> # After C4: {a1:[g1,g5,g7,g11,g14,g16,g22,g26], a2:[g2,g6,g15,g13,g25,g21],
+    >>> #            a3:[g4,g8,g10,g17,g12,g23,g19], a4:[g3,g9,g18,g24,g20]}.
+    >>> #
+    >>> # Final envy table: no envy among any agents. EF1 holds.
+    >>> # NOTE: marked SKIP — the exact output depends on lex tie-breaking across 26 goods.
+    >>> from fairpyx import Instance, divide  # doctest: +SKIP
+    >>> all_goods = [f'g{i}' for i in range(1, 27)]  # doctest: +SKIP
+    >>> valuations = {  # doctest: +SKIP
+    ...     'a1': {'g1':9,'g2':4,'g3':8,'g4':1,'g5':6,'g6':2,'g7':10,'g8':3,'g9':5,'g10':1,'g11':7,
+    ...            'g12':6,'g13':2,'g14':9,'g15':4,'g16':8,'g17':1,'g18':3,
+    ...            'g19':5,'g20':7,'g21':2,'g22':10,'g23':4,'g24':6,'g25':1,'g26':8},
+    ...     'a2': {'g1':3,'g2':10,'g3':2,'g4':7,'g5':5,'g6':9,'g7':1,'g8':8,'g9':4,'g10':6,'g11':2,
+    ...            'g12':1,'g13':7,'g14':3,'g15':10,'g16':5,'g17':8,'g18':4,
+    ...            'g19':6,'g20':2,'g21':9,'g22':1,'g23':7,'g24':3,'g25':10,'g26':5},
+    ...     'a3': {'g1':8,'g2':1,'g3':5,'g4':9,'g5':2,'g6':4,'g7':6,'g8':10,'g9':1,'g10':7,'g11':3,
+    ...            'g12':9,'g13':5,'g14':2,'g15':6,'g16':1,'g17':10,'g18':4,
+    ...            'g19':8,'g20':3,'g21':6,'g22':2,'g23':9,'g24':1,'g25':5,'g26':7},
+    ...     'a4': {'g1':2,'g2':6,'g3':10,'g4':3,'g5':7,'g6':5,'g7':2,'g8':1,'g9':10,'g10':8,'g11':4,
+    ...            'g12':3,'g13':9,'g14':6,'g15':2,'g16':7,'g17':5,'g18':10,
+    ...            'g19':1,'g20':8,'g21':4,'g22':6,'g23':2,'g24':10,'g25':3,'g26':9},
+    ... }
+    >>> item_categories = {  # doctest: +SKIP
+    ...     'C1': ['g1','g2','g3','g4','g5'],
+    ...     'C2': ['g6','g7','g8','g9','g10','g11'],
+    ...     'C3': ['g12','g13','g14','g15','g16','g17','g18'],
+    ...     'C4': ['g19','g20','g21','g22','g23','g24','g25','g26'],
+    ... }
+    >>> category_capacities = {'C1': 2, 'C2': 2, 'C3': 2, 'C4': 2}  # doctest: +SKIP
+    >>> instance = Instance(valuations=valuations)  # doctest: +SKIP
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,  # doctest: +SKIP
+    ...        item_categories=item_categories, category_capacities=category_capacities,
+    ...        initial_agent_order=['a1', 'a2', 'a3', 'a4'])
+    {'a1': ['g1', 'g11', 'g14', 'g16', 'g22', 'g26', 'g5', 'g7'], 'a2': ['g13', 'g15', 'g2', 'g21', 'g25', 'g6'], 'a3': ['g10', 'g12', 'g17', 'g19', 'g23', 'g4', 'g8'], 'a4': ['g18', 'g20', 'g24', 'g3', 'g9']}
 
-    >>> # Example 12: invalid — an agent is missing a threshold for a category raises ValueError
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
-    >>> item_categories = {'c1': ['m1']}
-    >>> agent_category_capacities_bad = {'Agent1': {'c1': 1}, 'Agent2': {}}
-    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities_bad,
-    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 13: invalid — initial_agent_order is empty while instance has agents raises ValueError
-    >>> # (Instance(valuations={}) cannot be constructed; test zero-order case instead)
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
-    >>> item_categories = {'c1': ['m1']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 0}}
-    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=[])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 14: invalid — duplicate agent in initial_agent_order raises ValueError
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
-    >>> item_categories = {'c1': ['m1']}
-    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 0}}
-    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['Agent1', 'Agent1'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 15: invalid — a good is in the instance but missing from all categories raises ValueError
-    >>> from fairpyx import Instance, divide
-    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3}, 'Agent2': {'m1': 3, 'm2': 5}}
-    >>> item_categories_incomplete = {'c1': ['m1']}  # m2 is not in any category
-    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 1, 'Agent2': 1})
-    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
-    ...        item_categories=item_categories_incomplete, agent_category_capacities=agent_category_capacities,
-    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
+    # Invalid-input tests (negative valuations, k_h too small, duplicate goods across
+    # categories, non-positive k_h, empty/duplicate initial_agent_order, uncategorised
+    # goods) are covered in full by the doctests of validate_fair_division_inputs.
     """
-    # --- Section: validate all inputs before proceeding ---
-    # validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, initial_agent_order)
 
-    # --- Section: initialise current agent order ---
-    # current_order = initial_agent_order
-    # logger.info("Starting fair_division_under_cardinality_constraints. Initial order: %s", current_order)
 
-    # --- Section: main loop — process one category at a time (Algorithm 1, step 3) ---
-    # for category in item_categories:
-    #     logger.info("Processing category '%s' with agent order %s", category, current_order)
-    #
-    #     # Step 4: allocate goods in this category using Greedy Round-Robin (Algorithm 2)
-    #     greedy_round_robin(alloc, item_categories[category], current_order,
-    #                        agent_category_capacities, category)
-    #     logger.info("Bundles after greedy_round_robin for '%s': %s", category, alloc.bundles)
-    #
-    #     # Step 6: eliminate envy cycles and obtain an acyclic envy graph (Lemma 1)
-    #     envy_graph = eliminate_envy_cycles(alloc)
-    #     logger.info("Envy graph after cycle elimination: %s", list(envy_graph.edges))
-    #
-    #     # Step 7: update agent order to the topological sort of the acyclic envy graph
-    #     current_order = list(nx.topological_sort(envy_graph))
-    #     logger.info("Updated agent order: %s", current_order)
-
-    # logger.info("Final allocation: %s", alloc.bundles)
     pass
 
 
@@ -299,12 +375,11 @@ def greedy_round_robin(
     alloc: AllocationBuilder,
     items_in_category: list,
     agent_order: list,
-    agent_category_capacities: dict,
+    category_capacities: dict,
     category: str,
 ) -> None:
     """
-    Allocate all goods from a single category using Greedy Round-Robin (Algorithm 2,
-    Biswas & Barman 2018).
+    Allocate all goods from a single category using Greedy Round-Robin (Algorithm 2).
 
     Agents pick in round-robin order, cycling repeatedly. On each turn an agent greedily
     selects the remaining good in the category it values most, subject to its per-category
@@ -317,17 +392,17 @@ def greedy_round_robin(
         in this round.
     :param agent_order: the ordered list of agents specifying the picking sequence for this
         category (either initial_agent_order or the topological sort from the previous category).
-    :param agent_category_capacities: a dictionary mapping each agent name (str) to a
-        dictionary of per-category integer capacities.
+    :param category_capacities: a dictionary mapping each category name (str) to the shared
+        integer threshold k_h for that category.
     :param category: the name (str) of the category currently being allocated.
 
     >>> # Example 1: 2 agents, 2 goods, k_h=1 — each agent picks their top good
     >>> from fairpyx import Instance, AllocationBuilder
     >>> valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 8}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> agent_category_capacities = {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}
-    >>> greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], agent_category_capacities, 'c1')
+    >>> category_capacities = {'c1': 1}
+    >>> greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], category_capacities, 'c1')
     >>> alloc.sorted()
     {'Alice': ['m1'], 'Bob': ['m2']}
 
@@ -335,52 +410,31 @@ def greedy_round_robin(
     >>> valuations = {'A': {'m1': 9, 'm2': 5, 'm3': 1},
     ...               'B': {'m1': 3, 'm2': 9, 'm3': 2},
     ...               'C': {'m1': 2, 'm2': 4, 'm3': 8}}
-    >>> agent_category_capacities = {'A': {'c1': 1}, 'B': {'c1': 1}, 'C': {'c1': 1}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'],
-    ...                     agent_capacities={'A': 1, 'B': 1, 'C': 1})
+    >>> category_capacities = {'c1': 1}
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3'], ['A', 'B', 'C'], agent_category_capacities, 'c1')
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3'], ['A', 'B', 'C'], category_capacities, 'c1')
     >>> alloc.sorted()
     {'A': ['m1'], 'B': ['m2'], 'C': ['m3']}
 
     >>> # Example 3: 2 agents, 4 goods, k_h=2 — each agent picks 2 goods
     >>> valuations = {'Alice': {'m1': 10, 'm2': 8, 'm3': 5, 'm4': 3},
     ...               'Bob':   {'m1': 3,  'm2': 5, 'm3': 8, 'm4': 10}}
-    >>> agent_category_capacities = {'Alice': {'c1': 2}, 'Bob': {'c1': 2}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3', 'm4'],
-    ...                     agent_capacities={'Alice': 2, 'Bob': 2})
+    >>> category_capacities = {'c1': 2}
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], agent_category_capacities, 'c1')
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], category_capacities, 'c1')
     >>> alloc.sorted()
     {'Alice': ['m1', 'm2'], 'Bob': ['m3', 'm4']}
     """
-    # --- Section: initialise per-category remaining capacities ---
-    # remaining_caps = {agent: agent_category_capacities[agent][category] for agent in agent_order}
 
-    # --- Section: keep track of which agents still have capacity and which goods remain ---
-    # remaining_goods = [g for g in alloc.remaining_items() if g in items_in_category]
-    # agents_with_capacity = set(agent for agent in agent_order if remaining_caps[agent] > 0)
-
-    # --- Section: cycle through agent_order, each picks their best remaining good ---
-    # for agent in cycle(agent_order):
-    #     if not remaining_goods or not agents_with_capacity:
-    #         break
-    #     if agent not in agents_with_capacity:
-    #         continue
-    #     best_good = max(remaining_goods, key=lambda g: alloc.instance.agent_item_value(agent, g))
-    #     alloc.give(agent, best_good, logger)
-    #     remaining_goods.remove(best_good)
-    #     remaining_caps[agent] -= 1
-    #     if remaining_caps[agent] == 0:
-    #         agents_with_capacity.discard(agent)
     pass
 
 
-def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
+def eliminate_envy_cycles(alloc: AllocationBuilder) -> nz.DiGraph:
     """
     Build the envy graph for the current (partial) allocation, eliminate all directed cycles
-    by rotating bundles along each cycle, and return the resulting acyclic envy graph
-    (Lemma 1, Biswas & Barman 2018).
+    by rotating bundles along each cycle, and return the resulting acyclic envy graph (Lemma 1).
 
     Envy relation: agent i envies agent j if
         sum_{g in A_j} v_i(g) > sum_{g in A_i} v_i(g).
@@ -391,7 +445,7 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
     The paper proves that no agent's value decreases under such a rotation. This is repeated
     until the graph contains no directed cycles (i.e., it is a DAG).
 
-    The returned DAG is passed to nx.topological_sort to derive the agent order for the next
+    The returned DAG is passed to nz.topological_sort to derive the agent order for the next
     category: agents with no incoming envy edges (nobody envies them) pick first.
 
     :param alloc: an allocation builder whose alloc.bundles reflect the current partial
@@ -401,14 +455,14 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
 
     >>> # Example 1: no envy — graph is already a DAG, bundles are unchanged
     >>> from fairpyx import Instance, AllocationBuilder
-    >>> import networkz as nx
+    >>> import networkz as nz
     >>> valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 9}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'])
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
     >>> alloc.give('Alice', 'm1')
     >>> alloc.give('Bob', 'm2')
     >>> G = eliminate_envy_cycles(alloc)
-    >>> list(nx.simple_cycles(G))
+    >>> list(nz.simple_cycles(G))
     []
     >>> sorted(alloc.bundles['Alice'])
     ['m1']
@@ -419,12 +473,12 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
     >>> # Alice has m1 (she values at 3), Bob has m2 (he values at 3).
     >>> # Alice envies Bob (values m2=7 > m1=3) and Bob envies Alice (values m1=7 > m2=3).
     >>> valuations = {'Alice': {'m1': 3, 'm2': 7}, 'Bob': {'m1': 7, 'm2': 3}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'])
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
     >>> alloc.give('Alice', 'm1')
     >>> alloc.give('Bob', 'm2')
     >>> G = eliminate_envy_cycles(alloc)
-    >>> list(nx.simple_cycles(G))
+    >>> list(nz.simple_cycles(G))
     []
     >>> sorted(alloc.bundles['Alice'])
     ['m2']
@@ -438,13 +492,13 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
     >>> valuations = {'A': {'m1': 3, 'm2': 5, 'm3': 1},
     ...               'B': {'m1': 1, 'm2': 3, 'm3': 5},
     ...               'C': {'m1': 5, 'm2': 1, 'm3': 3}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'])
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
     >>> alloc.give('A', 'm1')
     >>> alloc.give('B', 'm2')
     >>> alloc.give('C', 'm3')
     >>> G = eliminate_envy_cycles(alloc)
-    >>> list(nx.simple_cycles(G))
+    >>> list(nz.simple_cycles(G))
     []
     >>> sorted(alloc.bundles['A'])
     ['m2']
@@ -453,189 +507,329 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
     >>> sorted(alloc.bundles['C'])
     ['m1']
     """
-    # --- Section: build the envy graph ---
-    # envy_graph = nx.DiGraph()
-    # agents = list(alloc.bundles.keys())
-    # envy_graph.add_nodes_from(agents)
-    # for agent_i in agents:
-    #     val_i_own = sum(alloc.instance.agent_item_value(agent_i, g) for g in alloc.bundles[agent_i])
-    #     for agent_j in agents:
-    #         if agent_i == agent_j:
-    #             continue
-    #         val_i_other = sum(alloc.instance.agent_item_value(agent_i, g) for g in alloc.bundles[agent_j])
-    #         if val_i_other > val_i_own:
-    #             envy_graph.add_edge(agent_i, agent_j)
 
-    # --- Section: eliminate cycles iteratively ---
-    # while not nx.is_directed_acyclic_graph(envy_graph):
-    #     cycle_nodes = next(nx.simple_cycles(envy_graph))  # list of agents forming one cycle
-    #     # rotate bundles: a_0 gets a_1's bundle, a_1 gets a_2's bundle, ..., a_{r-1} gets a_0's bundle
-    #     first_bundle = alloc.bundles[cycle_nodes[0]].copy()
-    #     for i in range(len(cycle_nodes) - 1):
-    #         alloc.bundles[cycle_nodes[i]] = alloc.bundles[cycle_nodes[i + 1]].copy()
-    #     alloc.bundles[cycle_nodes[-1]] = first_bundle
-    #     # rebuild the envy graph with updated bundles
-    #     envy_graph = ... (repeat edge construction above)
+    return nz.DiGraph()  # placeholder so callers see a DiGraph, not None
 
-    # --- Section: return the acyclic envy graph ---
-    # return envy_graph
-    return nx.DiGraph()  # placeholder so callers see a DiGraph, not None
 
 
 def validate_fair_division_inputs(
     alloc: AllocationBuilder,
     item_categories: dict,
-    agent_category_capacities: dict,
+    category_capacities: dict,
     initial_agent_order: list,
 ):
     """
     Validate all inputs for fair_division_under_cardinality_constraints before the algorithm runs.
 
     Checks performed (in order):
-    - At least one agent exists.
-    - Keys of agent_category_capacities match the set of agents in alloc.instance exactly.
-    - initial_agent_order contains each agent exactly once (no duplicates, no missing agents).
-    - No item appears in more than one category.
-    - Every item listed in item_categories appears in the instance valuations.
-    - Every item in the instance valuations appears in exactly one category (no uncategorised goods).
-    - All thresholds k_h are positive integers.
-    - All agents share the same k_h for each category (uniformity required by the paper).
-    - Each k_h satisfies k_h >= ceil(|C_h| / n) — the feasibility condition from the paper.
-    - All valuation values are non-negative.
+
+    Type checks (correct input format):
+    1. initial_agent_order is either None (use sorted agents as default) or a list.
+    2. item_categories is a dict (correct type).
+    3. category_capacities is a dict (correct type).
+    4. item_categories values are all lists (correct type).
+
+    Existence/non-empty checks:
+    5. At least one agent exists in the instance.
+    6. At least one category exists in item_categories.
+    7. Every category in item_categories has at least one item (no empty category lists).
+
+    Consistency checks (inputs match each other):
+    8. If initial_agent_order is not None, it must be a valid permutation of the agents —
+       contains each agent exactly once (no duplicates, no missing agents, no extra agents
+       not in the instance). If None, this check is skipped.
+    9. category_capacities keys match item_categories keys exactly (every category has a
+       threshold, no threshold for a non-existent category).
+    10. Every item listed in item_categories appears in the instance valuations.
+    11. Every item in the instance valuations appears in at least one category (no uncategorised goods).
+    12. No item appears in more than one category.
+
+    Mathematical/feasibility checks:
+    13. All valuation values are non-negative (>= 0).
+    14. All thresholds k_h in category_capacities are positive integers.
+    15. Each k_h satisfies k_h >= ceil(|C_h| / n) — the feasibility condition from the paper.
 
     :param alloc: an allocation builder, which tracks the allocation and the remaining capacity
         for items and agents.
     :param item_categories: a dictionary mapping each category name (str) to a list of item
         names belonging to that category. Example: {'c1': ['m1', 'm2'], 'c2': ['m3']}.
-    :param agent_category_capacities: a dictionary mapping each agent name (str) to a dictionary
-        of per-category integer capacities (the thresholds k_h). All agents must share the same
-        k_h for each category h. Example: {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}.
-    :param initial_agent_order: a list of agent names specifying the initial picking order.
-        Must contain each agent exactly once.
+    :param category_capacities: a dictionary mapping each category name (str) to the shared
+        integer threshold k_h (max goods any agent may receive from that category).
+        Example: {'c1': 1, 'c2': 2}.
+    :param initial_agent_order: a list of agent names specifying the initial picking order,
+        or None to use sorted(agents) as the default order.
+        If a list, must contain each agent exactly once.
     :raises ValueError: if any of the above conditions are violated.
 
-    >>> # Example 1: valid inputs — no exception raised
+    # -------------------------------------------------------------------
+    # Setup: base instance used across most tests
+    # -------------------------------------------------------------------
+
     >>> from fairpyx import Instance, AllocationBuilder
     >>> valuations = {'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}}
-    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
     >>> item_categories = {'c1': ['m1', 'm2']}
-    >>> agent_category_capacities = {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}
-    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, ['Alice', 'Bob'])
+    >>> category_capacities = {'c1': 1}
 
-    >>> # Example 2: invalid — initial_agent_order is empty while instance has agents raises ValueError
-    >>> # (Instance(valuations={}) cannot be constructed; test zero-order case instead)
-    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, [])  # doctest: +ELLIPSIS
+    >>> # Valid inputs with explicit agent order — no exception raised
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Bob'])
+
+    >>> # Valid inputs with None — uses sorted agents as default, no exception raised
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, None)
+
+    # -------------------------------------------------------------------
+    # Check 1: initial_agent_order is either None or a list (correct type).
+    # -------------------------------------------------------------------
+
+    >>> # [check 1] invalid — initial_agent_order is a tuple instead of a list raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ('Alice', 'Bob'))
     Traceback (most recent call last):
         ...
     ValueError: ...
 
-    >>> # Example 3: invalid — negative valuation raises ValueError
+    >>> # [check 1] invalid — initial_agent_order is a set instead of a list raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, {'Alice', 'Bob'})
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 2: item_categories is a dict (correct type).
+    # -------------------------------------------------------------------
+
+    >>> # [check 2] invalid — item_categories is a list instead of a dict raises ValueError
+    >>> validate_fair_division_inputs(alloc, [('c1', ['m1', 'm2'])], category_capacities, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 2] invalid — item_categories is None instead of a dict raises ValueError
+    >>> validate_fair_division_inputs(alloc, None, category_capacities, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 3: category_capacities is a dict (correct type).
+    # -------------------------------------------------------------------
+
+    >>> # [check 3] invalid — category_capacities is a list instead of a dict raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, [('c1', 1)], ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 3] invalid — category_capacities is None instead of a dict raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, None, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 4: item_categories values are all lists (correct type).
+    # -------------------------------------------------------------------
+
+    >>> # [check 4] invalid — a category value is a tuple instead of a list raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ('m1', 'm2')}, category_capacities, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 4] invalid — a category value is a set instead of a list raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': {'m1', 'm2'}}, category_capacities, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 5] invalid — initial_agent_order is empty list (no agents given) raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, [])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 5] invalid — instance has empty valuations (no agents, no items), order is None raises ValueError
+    >>> empty_instance = Instance(valuations={})
+    >>> empty_alloc = AllocationBuilder(empty_instance)
+    >>> validate_fair_division_inputs(empty_alloc, item_categories, category_capacities, None)
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 6: At least one category exists in item_categories.
+    # -------------------------------------------------------------------
+
+    >>> # [check 6] invalid — item_categories is empty (no categories at all) raises ValueError
+    >>> validate_fair_division_inputs(alloc, {}, {}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 7: Every category in item_categories has at least one item.
+    # -------------------------------------------------------------------
+
+    >>> # [check 7] invalid — category 'c1' has an empty item list raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': []}, {'c1': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 7] invalid — one category is empty, one is not raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2'], 'c2': []}, {'c1': 1, 'c2': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 8: initial_agent_order is a valid permutation of the agents (skipped if None).
+    # -------------------------------------------------------------------
+
+    >>> # [check 8] valid — None skips the permutation check entirely, no exception raised
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, None)
+
+    >>> # [check 8] invalid — agent missing from initial_agent_order raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 8] invalid — duplicate agent in initial_agent_order raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Alice'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 8] invalid — agent in initial_agent_order not in instance raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Charlie'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 8] invalid — agent in initial_agent_order not in instance raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Bob', 'Charlie'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 9: category_capacities keys match item_categories keys exactly.
+    # -------------------------------------------------------------------
+
+    >>> # [check 9] invalid — category_capacities missing a threshold for an existing category raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1'], 'c2': ['m2']}, {'c1': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 9] invalid — category_capacities has a key for a category not in item_categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': 1, 'c99': 2}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 9] invalid — category_capacities has a key for a category not in item_categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': 1, 'c2': 2, 'c99': 2}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 10: Every item listed in item_categories appears in the instance valuations.
+    # -------------------------------------------------------------------
+
+    >>> # [check 10] invalid — item 'm99' is in item_categories but not in instance valuations raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1', 'm99']}, {'c1': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 11: Every item in the instance valuations appears in at least one category.
+    # -------------------------------------------------------------------
+
+    >>> # [check 11] invalid — item 'm2' is in the instance valuations but missing from all categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 12: No item appears in more than one category.
+    # -------------------------------------------------------------------
+
+    >>> # [check 12] invalid — item 'm1' appears in two categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2'], 'c2': ['m1']}, {'c1': 1, 'c2': 1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 13: All valuation values are non-negative (>= 0).
+    # -------------------------------------------------------------------
+
+    >>> # [check 13] valid — valuation of exactly 0 is allowed, no exception raised
+    >>> valuations_zero = {'Alice': {'m1': 0, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}}
+    >>> instance_zero = Instance(valuations=valuations_zero)
+    >>> alloc_zero = AllocationBuilder(instance_zero)
+    >>> validate_fair_division_inputs(alloc_zero, {'c1': ['m1', 'm2']}, {'c1': 1}, ['Alice', 'Bob'])
+
+    >>> # [check 13] invalid — negative valuation raises ValueError
     >>> valuations_neg = {'Alice': {'m1': -1, 'm2': 3}, 'Bob': {'m1': 4, 'm2': 6}}
-    >>> instance_neg = Instance(valuations=valuations_neg, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> instance_neg = Instance(valuations=valuations_neg)
     >>> alloc_neg = AllocationBuilder(instance_neg)
-    >>> validate_fair_division_inputs(alloc_neg, {'c1': ['m1', 'm2']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    >>> validate_fair_division_inputs(alloc_neg, {'c1': ['m1', 'm2']}, {'c1': 1}, ['Alice', 'Bob'])
     Traceback (most recent call last):
         ...
     ValueError: ...
 
-    >>> # Example 4: invalid — k_h too small (k_h=1 < ceil(3/2)=2) raises ValueError
+    # -------------------------------------------------------------------
+    # Check 14: All thresholds k_h in category_capacities are positive integers.
+    # -------------------------------------------------------------------
+
+    >>> # [check 14] invalid — k_h=0 is not a positive integer raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': 0}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 14] invalid — k_h=-1 is not a positive integer raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': -1}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 14] invalid — k_h=1.5 is not an integer raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': 1.5}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # [check 14] invalid — k_h='1' is a string not an integer raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'c1': '1'}, ['Alice', 'Bob'])
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    # -------------------------------------------------------------------
+    # Check 15: Each k_h satisfies k_h >= ceil(|C_h| / n) — feasibility condition.
+    # -------------------------------------------------------------------
+
+    >>> # [check 15] invalid — k_h=1 < ceil(3/2)=2 for 3 items and 2 agents raises ValueError
     >>> valuations_3 = {'Alice': {'m1': 5, 'm2': 3, 'm3': 1}, 'Bob': {'m1': 1, 'm2': 3, 'm3': 5}}
-    >>> instance_3 = Instance(valuations=valuations_3, items=['m1', 'm2', 'm3'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> instance_3 = Instance(valuations=valuations_3)
     >>> alloc_3 = AllocationBuilder(instance_3)
-    >>> validate_fair_division_inputs(alloc_3, {'c1': ['m1', 'm2', 'm3']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    >>> validate_fair_division_inputs(alloc_3, {'c1': ['m1', 'm2', 'm3']}, {'c1': 1}, ['Alice', 'Bob'])
     Traceback (most recent call last):
         ...
     ValueError: ...
 
-    >>> # Example 5: invalid — item appears in two categories raises ValueError
-    >>> validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2'], 'c2': ['m1']}, {'Alice': {'c1': 1, 'c2': 1}, 'Bob': {'c1': 1, 'c2': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 6: invalid — an agent is missing a threshold for one of the categories raises ValueError
-    >>> validate_fair_division_inputs(alloc, item_categories, {'Alice': {'c1': 1}, 'Bob': {}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 7: invalid — duplicate agent in initial_agent_order raises ValueError
-    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, ['Alice', 'Alice'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
-
-    >>> # Example 8: invalid — item present in valuations but missing from all categories raises ValueError
-    >>> validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    ValueError: ...
+    >>> # [check 15] valid — k_h=2 == ceil(3/2)=2, exactly on the boundary — no exception raised
+    >>> validate_fair_division_inputs(alloc_3, {'c1': ['m1', 'm2', 'm3']}, {'c1': 2}, ['Alice', 'Bob'])
     """
-    # --- Section: check at least one agent exists ---
-    # agents = list(alloc.instance.agents)
-    # if len(agents) == 0:
-    #     raise ValueError("No agents found in the instance.")
 
-    # --- Section: check agent_category_capacities keys match instance agents exactly ---
-    # if set(agent_category_capacities.keys()) != set(agents):
-    #     raise ValueError("agent_category_capacities agents do not match the instance agents.")
-
-    # --- Section: check initial_agent_order has no duplicates and covers all agents ---
-    # if len(initial_agent_order) != len(set(initial_agent_order)):
-    #     raise ValueError("initial_agent_order contains duplicate agents.")
-    # if set(initial_agent_order) != set(agents):
-    #     raise ValueError("initial_agent_order does not match the instance agents.")
-
-    # --- Section: check no item appears in more than one category ---
-    # all_items_in_categories = [item for items in item_categories.values() for item in items]
-    # if len(all_items_in_categories) != len(set(all_items_in_categories)):
-    #     raise ValueError("An item appears in more than one category.")
-
-    # --- Section: check every categorised item is known to the instance ---
-    # instance_items = set(alloc.instance.items)
-    # for item in all_items_in_categories:
-    #     if item not in instance_items:
-    #         raise ValueError(f"Item '{item}' in item_categories is not present in the instance.")
-
-    # --- Section: check every instance item appears in exactly one category ---
-    # categorised_items = set(all_items_in_categories)
-    # for item in instance_items:
-    #     if item not in categorised_items:
-    #         raise ValueError(f"Item '{item}' is in the instance but not assigned to any category.")
-
-    # --- Section: check all k_h values are positive integers and uniform across agents ---
-    # for category in item_categories:
-    #     capacities_for_category = []
-    #     for agent in agents:
-    #         if category not in agent_category_capacities[agent]:
-    #             raise ValueError(f"Agent '{agent}' has no threshold for category '{category}'.")
-    #         k = agent_category_capacities[agent][category]
-    #         if not isinstance(k, int) or k < 1:
-    #             raise ValueError(f"Threshold for agent '{agent}', category '{category}' must be a positive integer.")
-    #         capacities_for_category.append(k)
-    #     if len(set(capacities_for_category)) > 1:
-    #         raise ValueError(f"Thresholds for category '{category}' differ across agents (paper requires uniform k_h).")
-
-    # --- Section: check k_h >= ceil(|C_h| / n) for feasibility ---
-    # n = len(agents)
-    # for category, items in item_categories.items():
-    #     k_h = agent_category_capacities[agents[0]][category]
-    #     required = math.ceil(len(items) / n)
-    #     if k_h < required:
-    #         raise ValueError(
-    #             f"Threshold k_{category}={k_h} is too small for {len(items)} goods and {n} agents "
-    #             f"(need k_h >= ceil({len(items)}/{n}) = {required})."
-    #         )
-
-    # --- Section: check all valuations are non-negative ---
-    # for agent in agents:
-    #     for item in alloc.instance.items:
-    #         val = alloc.instance.agent_item_value(agent, item)
-    #         if val < 0:
-    #             raise ValueError(f"Valuation of agent '{agent}' for item '{item}' is negative ({val}).")
     pass
-
 
 
 if __name__ == "__main__":

--- a/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
+++ b/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
@@ -1,0 +1,643 @@
+"""
+An implementation of the algorithm in:
+"Fair Division Under Cardinality Constraints", by A. Biswas, S. Barman (2018), https://arxiv.org/abs/1804.09521
+Programmer: Sapir Dahan
+Date : 2026-04
+"""
+
+import math
+import logging
+
+import networkz as nx
+
+from fairpyx import Instance, AllocationBuilder
+
+logger = logging.getLogger(__name__)
+
+
+
+def fair_division_under_cardinality_constraints(
+    alloc: AllocationBuilder,
+    item_categories: dict,
+    agent_category_capacities: dict,
+    initial_agent_order: list,
+):
+    """
+    Compute a feasible EF1 allocation under cardinality constraints (Algorithm 1,
+    Biswas & Barman 2018).
+
+    All agents share the same per-category threshold k_h. Valuations are additive and
+    may differ across agents. The algorithm guarantees EF1: for every pair of agents
+    (i, j) there exists some good g in j's bundle such that
+        v_i(A_i) >= v_i(A_j \\ {g}).
+
+    Procedure:
+      1. Validate all inputs via validate_fair_division_inputs.
+      2. For each category h in item_categories (in iteration order):
+         a. Call greedy_round_robin to allocate the goods in h using the current agent order.
+         b. Call eliminate_envy_cycles to remove all directed cycles from the envy graph and
+            obtain an acyclic envy graph G_h.
+         c. Derive the agent order for the next category as the topological sort of G_h
+            (agents with no incoming envy edges pick first in the next round).
+
+    :param alloc: an allocation builder, which tracks the allocation and the remaining
+        capacity for items and agents.
+    :param item_categories: a dictionary mapping each category name (str) to a list of
+        item names. Every item in the instance must appear in exactly one category.
+        Example: {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4', 'm5']}.
+    :param agent_category_capacities: a dictionary mapping each agent name (str) to a
+        dictionary of per-category integer capacities (k_h). All agents must have the same
+        k_h for each category. The sum of each agent's k_h values across all categories
+        should equal the agent_capacity passed to Instance.
+        Example: {'Agent1': {'c1': 1, 'c2': 2}, 'Agent2': {'c1': 1, 'c2': 2}}.
+    :param initial_agent_order: a list of agent names specifying the initial picking order
+        for the first category. Must contain each agent exactly once.
+
+    >>> # Example 1: basic — 2 agents, 2 categories, 1 good each, k_h=1
+    >>> # Agent1 prefers m1 and m3; Agent2 prefers m2 and m4.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {
+    ...     'Agent1': {'m1': 9, 'm2': 3, 'm3': 8, 'm4': 2},
+    ...     'Agent2': {'m1': 3, 'm2': 9, 'm3': 2, 'm4': 8},
+    ... }
+    >>> item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
+    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3', 'm4'], agent_capacities=sum_caps)
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])
+    {'Agent1': ['m1', 'm3'], 'Agent2': ['m2', 'm4']}
+
+    >>> # Example 2: 3 agents, 2 categories of 3 goods each, k_h=1
+    >>> # Each agent's top good in each category is unique, so the output is deterministic.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {
+    ...     'Agent1': {'m1': 9, 'm2': 6, 'm3': 3, 'm4': 8, 'm5': 5, 'm6': 2},
+    ...     'Agent2': {'m1': 3, 'm2': 9, 'm3': 6, 'm4': 2, 'm5': 8, 'm6': 5},
+    ...     'Agent3': {'m1': 6, 'm2': 3, 'm3': 9, 'm4': 5, 'm5': 2, 'm6': 8},
+    ... }
+    >>> item_categories = {'c1': ['m1', 'm2', 'm3'], 'c2': ['m4', 'm5', 'm6']}
+    >>> agent_category_capacities = {
+    ...     'Agent1': {'c1': 1, 'c2': 1},
+    ...     'Agent2': {'c1': 1, 'c2': 1},
+    ...     'Agent3': {'c1': 1, 'c2': 1},
+    ... }
+    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
+    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4','m5','m6'], agent_capacities=sum_caps)
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2', 'Agent3'])
+    {'Agent1': ['m1', 'm4'], 'Agent2': ['m2', 'm5'], 'Agent3': ['m3', 'm6']}
+
+    >>> # Example 3: single agent — trivially receives all goods (up to its capacity)
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Alice': {'m1': 10, 'm2': 7, 'm3': 4}}
+    >>> item_categories = {'c1': ['m1', 'm2', 'm3']}
+    >>> agent_category_capacities = {'Alice': {'c1': 3}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'], agent_capacities={'Alice': 3})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Alice'])
+    {'Alice': ['m1', 'm2', 'm3']}
+
+    >>> # Example 4: single category — degenerates to a single greedy_round_robin call
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'A': {'x': 10, 'y': 5, 'z': 1}, 'B': {'x': 1, 'y': 5, 'z': 10}}
+    >>> item_categories = {'c1': ['x', 'y', 'z']}
+    >>> agent_category_capacities = {'A': {'c1': 2}, 'B': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['x', 'y', 'z'], agent_capacities={'A': 2, 'B': 1})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['A', 'B'])
+    {'A': ['x', 'y'], 'B': ['z']}
+
+    >>> # Example 5: single good per category — each agent can receive at most one good per category
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 8, 'm2': 5}, 'Agent2': {'m1': 5, 'm2': 8}}
+    >>> item_categories = {'c1': ['m1'], 'c2': ['m2']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 2, 'Agent2': 2})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])
+    {'Agent1': ['m1'], 'Agent2': ['m2']}
+
+    >>> # Example 6: boundary case — k_h = ceil(|C_h| / n), exactly the minimum feasible threshold
+    >>> # 3 agents, 3 goods in c1, k_h = ceil(3/3) = 1.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {
+    ...     'A': {'g1': 9, 'g2': 6, 'g3': 3},
+    ...     'B': {'g1': 3, 'g2': 9, 'g3': 6},
+    ...     'C': {'g1': 6, 'g2': 3, 'g3': 9},
+    ... }
+    >>> item_categories = {'c1': ['g1', 'g2', 'g3']}
+    >>> agent_category_capacities = {'A': {'c1': 1}, 'B': {'c1': 1}, 'C': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['g1', 'g2', 'g3'], agent_capacities={'A': 1, 'B': 1, 'C': 1})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['A', 'B', 'C'])
+    {'A': ['g1'], 'B': ['g2'], 'C': ['g3']}
+
+    >>> # Example 7: asymmetric category sizes — c1 has 4 goods (k_h=2), c2 has 1 good (k_h=1)
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {
+    ...     'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4, 'm5': 9},
+    ...     'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10, 'm5': 7},
+    ... }
+    >>> item_categories = {'c1': ['m1', 'm2', 'm3', 'm4'], 'c2': ['m5']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 2, 'c2': 1}, 'Agent2': {'c1': 2, 'c2': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4','m5'],
+    ...                     agent_capacities={'Agent1': 3, 'Agent2': 3})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])
+    {'Agent1': ['m1', 'm2', 'm5'], 'Agent2': ['m3', 'm4']}
+
+    >>> # Example 8: EF1 property verification — for the result, no agent envies another
+    >>> # by more than the removal of one good from the other's bundle.
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {
+    ...     'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4},
+    ...     'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10},
+    ... }
+    >>> item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
+    >>> sum_caps = {a: sum(v.values()) for a, v in agent_category_capacities.items()}
+    >>> instance = Instance(valuations=valuations, items=['m1','m2','m3','m4'], agent_capacities=sum_caps)
+    >>> result = divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...                 item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...                 initial_agent_order=['Agent1', 'Agent2'])
+    >>> # EF1 check for Agent1: there exists a good in Agent2's bundle whose removal ends the envy
+    >>> v1 = valuations['Agent1']
+    >>> val1_own   = sum(v1[g] for g in result['Agent1'])
+    >>> val1_other = sum(v1[g] for g in result['Agent2'])
+    >>> val1_own >= val1_other - max(v1[g] for g in result['Agent2'])
+    True
+
+    >>> # Example 9: invalid — negative valuation raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': -1, 'm2': 3}, 'Agent2': {'m1': 4, 'm2': 6}}
+    >>> item_categories = {'c1': ['m1', 'm2']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 1, 'Agent2': 1})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 10: invalid — k_h too small (k_h=1 < ceil(3/2)=2) raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3, 'm3': 1}, 'Agent2': {'m1': 1, 'm2': 3, 'm3': 5}}
+    >>> item_categories = {'c1': ['m1', 'm2', 'm3']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'], agent_capacities={'Agent1': 1, 'Agent2': 1})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 11: invalid — a good appears in two categories raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3}, 'Agent2': {'m1': 3, 'm2': 5}}
+    >>> item_categories_dup = {'c1': ['m1', 'm2'], 'c2': ['m1']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1, 'c2': 1}, 'Agent2': {'c1': 1, 'c2': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 2, 'Agent2': 2})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories_dup, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 12: invalid — an agent is missing a threshold for a category raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
+    >>> item_categories = {'c1': ['m1']}
+    >>> agent_category_capacities_bad = {'Agent1': {'c1': 1}, 'Agent2': {}}
+    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities_bad,
+    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 13: invalid — initial_agent_order is empty while instance has agents raises ValueError
+    >>> # (Instance(valuations={}) cannot be constructed; test zero-order case instead)
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
+    >>> item_categories = {'c1': ['m1']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 0}}
+    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=[])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 14: invalid — duplicate agent in initial_agent_order raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5}, 'Agent2': {'m1': 3}}
+    >>> item_categories = {'c1': ['m1']}
+    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 0}}
+    >>> instance = Instance(valuations=valuations, items=['m1'], agent_capacities={'Agent1': 1, 'Agent2': 0})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent1'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 15: invalid — a good is in the instance but missing from all categories raises ValueError
+    >>> from fairpyx import Instance, divide
+    >>> valuations = {'Agent1': {'m1': 5, 'm2': 3}, 'Agent2': {'m1': 3, 'm2': 5}}
+    >>> item_categories_incomplete = {'c1': ['m1']}  # m2 is not in any category
+    >>> agent_category_capacities = {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Agent1': 1, 'Agent2': 1})
+    >>> divide(algorithm=fair_division_under_cardinality_constraints, instance=instance,
+    ...        item_categories=item_categories_incomplete, agent_category_capacities=agent_category_capacities,
+    ...        initial_agent_order=['Agent1', 'Agent2'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+    """
+    # --- Section: validate all inputs before proceeding ---
+    # validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, initial_agent_order)
+
+    # --- Section: initialise current agent order ---
+    # current_order = initial_agent_order
+    # logger.info("Starting fair_division_under_cardinality_constraints. Initial order: %s", current_order)
+
+    # --- Section: main loop — process one category at a time (Algorithm 1, step 3) ---
+    # for category in item_categories:
+    #     logger.info("Processing category '%s' with agent order %s", category, current_order)
+    #
+    #     # Step 4: allocate goods in this category using Greedy Round-Robin (Algorithm 2)
+    #     greedy_round_robin(alloc, item_categories[category], current_order,
+    #                        agent_category_capacities, category)
+    #     logger.info("Bundles after greedy_round_robin for '%s': %s", category, alloc.bundles)
+    #
+    #     # Step 6: eliminate envy cycles and obtain an acyclic envy graph (Lemma 1)
+    #     envy_graph = eliminate_envy_cycles(alloc)
+    #     logger.info("Envy graph after cycle elimination: %s", list(envy_graph.edges))
+    #
+    #     # Step 7: update agent order to the topological sort of the acyclic envy graph
+    #     current_order = list(nx.topological_sort(envy_graph))
+    #     logger.info("Updated agent order: %s", current_order)
+
+    # logger.info("Final allocation: %s", alloc.bundles)
+    pass
+
+
+def greedy_round_robin(
+    alloc: AllocationBuilder,
+    items_in_category: list,
+    agent_order: list,
+    agent_category_capacities: dict,
+    category: str,
+) -> None:
+    """
+    Allocate all goods from a single category using Greedy Round-Robin (Algorithm 2,
+    Biswas & Barman 2018).
+
+    Agents pick in round-robin order, cycling repeatedly. On each turn an agent greedily
+    selects the remaining good in the category it values most, subject to its per-category
+    capacity k_h. An agent is skipped once it has received k_h goods from this category.
+    The procedure terminates when all goods are allocated or all agents have reached capacity.
+
+    :param alloc: an allocation builder, which tracks the allocation and the remaining
+        capacity for items and agents.
+    :param items_in_category: the list of items belonging to the category being processed
+        in this round.
+    :param agent_order: the ordered list of agents specifying the picking sequence for this
+        category (either initial_agent_order or the topological sort from the previous category).
+    :param agent_category_capacities: a dictionary mapping each agent name (str) to a
+        dictionary of per-category integer capacities.
+    :param category: the name (str) of the category currently being allocated.
+
+    >>> # Example 1: 2 agents, 2 goods, k_h=1 — each agent picks their top good
+    >>> from fairpyx import Instance, AllocationBuilder
+    >>> valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 8}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> alloc = AllocationBuilder(instance)
+    >>> agent_category_capacities = {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}
+    >>> greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], agent_category_capacities, 'c1')
+    >>> alloc.sorted()
+    {'Alice': ['m1'], 'Bob': ['m2']}
+
+    >>> # Example 2: 3 agents, 3 goods, k_h=1 — each picks their unique top good in order
+    >>> valuations = {'A': {'m1': 9, 'm2': 5, 'm3': 1},
+    ...               'B': {'m1': 3, 'm2': 9, 'm3': 2},
+    ...               'C': {'m1': 2, 'm2': 4, 'm3': 8}}
+    >>> agent_category_capacities = {'A': {'c1': 1}, 'B': {'c1': 1}, 'C': {'c1': 1}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'],
+    ...                     agent_capacities={'A': 1, 'B': 1, 'C': 1})
+    >>> alloc = AllocationBuilder(instance)
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3'], ['A', 'B', 'C'], agent_category_capacities, 'c1')
+    >>> alloc.sorted()
+    {'A': ['m1'], 'B': ['m2'], 'C': ['m3']}
+
+    >>> # Example 3: 2 agents, 4 goods, k_h=2 — each agent picks 2 goods
+    >>> valuations = {'Alice': {'m1': 10, 'm2': 8, 'm3': 5, 'm4': 3},
+    ...               'Bob':   {'m1': 3,  'm2': 5, 'm3': 8, 'm4': 10}}
+    >>> agent_category_capacities = {'Alice': {'c1': 2}, 'Bob': {'c1': 2}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3', 'm4'],
+    ...                     agent_capacities={'Alice': 2, 'Bob': 2})
+    >>> alloc = AllocationBuilder(instance)
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], agent_category_capacities, 'c1')
+    >>> alloc.sorted()
+    {'Alice': ['m1', 'm2'], 'Bob': ['m3', 'm4']}
+    """
+    # --- Section: initialise per-category remaining capacities ---
+    # remaining_caps = {agent: agent_category_capacities[agent][category] for agent in agent_order}
+
+    # --- Section: keep track of which agents still have capacity and which goods remain ---
+    # remaining_goods = [g for g in alloc.remaining_items() if g in items_in_category]
+    # agents_with_capacity = set(agent for agent in agent_order if remaining_caps[agent] > 0)
+
+    # --- Section: cycle through agent_order, each picks their best remaining good ---
+    # for agent in cycle(agent_order):
+    #     if not remaining_goods or not agents_with_capacity:
+    #         break
+    #     if agent not in agents_with_capacity:
+    #         continue
+    #     best_good = max(remaining_goods, key=lambda g: alloc.instance.agent_item_value(agent, g))
+    #     alloc.give(agent, best_good, logger)
+    #     remaining_goods.remove(best_good)
+    #     remaining_caps[agent] -= 1
+    #     if remaining_caps[agent] == 0:
+    #         agents_with_capacity.discard(agent)
+    pass
+
+
+def eliminate_envy_cycles(alloc: AllocationBuilder) -> nx.DiGraph:
+    """
+    Build the envy graph for the current (partial) allocation, eliminate all directed cycles
+    by rotating bundles along each cycle, and return the resulting acyclic envy graph
+    (Lemma 1, Biswas & Barman 2018).
+
+    Envy relation: agent i envies agent j if
+        sum_{g in A_j} v_i(g) > sum_{g in A_i} v_i(g).
+    A directed edge i -> j is added to the graph when i envies j.
+
+    Cycle elimination: for a detected cycle (a_1, a_2, ..., a_r), rotate bundles so that
+    a_1 receives a_2's bundle, a_2 receives a_3's bundle, ..., a_r receives a_1's bundle.
+    The paper proves that no agent's value decreases under such a rotation. This is repeated
+    until the graph contains no directed cycles (i.e., it is a DAG).
+
+    The returned DAG is passed to nx.topological_sort to derive the agent order for the next
+    category: agents with no incoming envy edges (nobody envies them) pick first.
+
+    :param alloc: an allocation builder whose alloc.bundles reflect the current partial
+        allocation after the most recent greedy_round_robin call.
+    :return: a networkz DiGraph representing the acyclic envy graph after all cycles have
+        been eliminated.
+
+    >>> # Example 1: no envy — graph is already a DAG, bundles are unchanged
+    >>> from fairpyx import Instance, AllocationBuilder
+    >>> import networkz as nx
+    >>> valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 9}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'])
+    >>> alloc = AllocationBuilder(instance)
+    >>> alloc.give('Alice', 'm1')
+    >>> alloc.give('Bob', 'm2')
+    >>> G = eliminate_envy_cycles(alloc)
+    >>> list(nx.simple_cycles(G))
+    []
+    >>> sorted(alloc.bundles['Alice'])
+    ['m1']
+    >>> sorted(alloc.bundles['Bob'])
+    ['m2']
+
+    >>> # Example 2: 2-agent envy cycle — bundles are swapped to eliminate the cycle
+    >>> # Alice has m1 (she values at 3), Bob has m2 (he values at 3).
+    >>> # Alice envies Bob (values m2=7 > m1=3) and Bob envies Alice (values m1=7 > m2=3).
+    >>> valuations = {'Alice': {'m1': 3, 'm2': 7}, 'Bob': {'m1': 7, 'm2': 3}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'])
+    >>> alloc = AllocationBuilder(instance)
+    >>> alloc.give('Alice', 'm1')
+    >>> alloc.give('Bob', 'm2')
+    >>> G = eliminate_envy_cycles(alloc)
+    >>> list(nx.simple_cycles(G))
+    []
+    >>> sorted(alloc.bundles['Alice'])
+    ['m2']
+    >>> sorted(alloc.bundles['Bob'])
+    ['m1']
+
+    >>> # Example 3: 3-agent cycle — bundle rotation resolves all envy
+    >>> # A has m1, B has m2, C has m3.
+    >>> # A envies B (5>3), B envies C (5>3), C envies A (5>3) — a 3-cycle.
+    >>> # After rotation: A gets m2, B gets m3, C gets m1 — no agent envies another.
+    >>> valuations = {'A': {'m1': 3, 'm2': 5, 'm3': 1},
+    ...               'B': {'m1': 1, 'm2': 3, 'm3': 5},
+    ...               'C': {'m1': 5, 'm2': 1, 'm3': 3}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2', 'm3'])
+    >>> alloc = AllocationBuilder(instance)
+    >>> alloc.give('A', 'm1')
+    >>> alloc.give('B', 'm2')
+    >>> alloc.give('C', 'm3')
+    >>> G = eliminate_envy_cycles(alloc)
+    >>> list(nx.simple_cycles(G))
+    []
+    >>> sorted(alloc.bundles['A'])
+    ['m2']
+    >>> sorted(alloc.bundles['B'])
+    ['m3']
+    >>> sorted(alloc.bundles['C'])
+    ['m1']
+    """
+    # --- Section: build the envy graph ---
+    # envy_graph = nx.DiGraph()
+    # agents = list(alloc.bundles.keys())
+    # envy_graph.add_nodes_from(agents)
+    # for agent_i in agents:
+    #     val_i_own = sum(alloc.instance.agent_item_value(agent_i, g) for g in alloc.bundles[agent_i])
+    #     for agent_j in agents:
+    #         if agent_i == agent_j:
+    #             continue
+    #         val_i_other = sum(alloc.instance.agent_item_value(agent_i, g) for g in alloc.bundles[agent_j])
+    #         if val_i_other > val_i_own:
+    #             envy_graph.add_edge(agent_i, agent_j)
+
+    # --- Section: eliminate cycles iteratively ---
+    # while not nx.is_directed_acyclic_graph(envy_graph):
+    #     cycle_nodes = next(nx.simple_cycles(envy_graph))  # list of agents forming one cycle
+    #     # rotate bundles: a_0 gets a_1's bundle, a_1 gets a_2's bundle, ..., a_{r-1} gets a_0's bundle
+    #     first_bundle = alloc.bundles[cycle_nodes[0]].copy()
+    #     for i in range(len(cycle_nodes) - 1):
+    #         alloc.bundles[cycle_nodes[i]] = alloc.bundles[cycle_nodes[i + 1]].copy()
+    #     alloc.bundles[cycle_nodes[-1]] = first_bundle
+    #     # rebuild the envy graph with updated bundles
+    #     envy_graph = ... (repeat edge construction above)
+
+    # --- Section: return the acyclic envy graph ---
+    # return envy_graph
+    return nx.DiGraph()  # placeholder so callers see a DiGraph, not None
+
+
+def validate_fair_division_inputs(
+    alloc: AllocationBuilder,
+    item_categories: dict,
+    agent_category_capacities: dict,
+    initial_agent_order: list,
+):
+    """
+    Validate all inputs for fair_division_under_cardinality_constraints before the algorithm runs.
+
+    Checks performed (in order):
+    - At least one agent exists.
+    - Keys of agent_category_capacities match the set of agents in alloc.instance exactly.
+    - initial_agent_order contains each agent exactly once (no duplicates, no missing agents).
+    - No item appears in more than one category.
+    - Every item listed in item_categories appears in the instance valuations.
+    - Every item in the instance valuations appears in exactly one category (no uncategorised goods).
+    - All thresholds k_h are positive integers.
+    - All agents share the same k_h for each category (uniformity required by the paper).
+    - Each k_h satisfies k_h >= ceil(|C_h| / n) — the feasibility condition from the paper.
+    - All valuation values are non-negative.
+
+    :param alloc: an allocation builder, which tracks the allocation and the remaining capacity
+        for items and agents.
+    :param item_categories: a dictionary mapping each category name (str) to a list of item
+        names belonging to that category. Example: {'c1': ['m1', 'm2'], 'c2': ['m3']}.
+    :param agent_category_capacities: a dictionary mapping each agent name (str) to a dictionary
+        of per-category integer capacities (the thresholds k_h). All agents must share the same
+        k_h for each category h. Example: {'Agent1': {'c1': 1}, 'Agent2': {'c1': 1}}.
+    :param initial_agent_order: a list of agent names specifying the initial picking order.
+        Must contain each agent exactly once.
+    :raises ValueError: if any of the above conditions are violated.
+
+    >>> # Example 1: valid inputs — no exception raised
+    >>> from fairpyx import Instance, AllocationBuilder
+    >>> valuations = {'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}}
+    >>> instance = Instance(valuations=valuations, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> alloc = AllocationBuilder(instance)
+    >>> item_categories = {'c1': ['m1', 'm2']}
+    >>> agent_category_capacities = {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}
+    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, ['Alice', 'Bob'])
+
+    >>> # Example 2: invalid — initial_agent_order is empty while instance has agents raises ValueError
+    >>> # (Instance(valuations={}) cannot be constructed; test zero-order case instead)
+    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, [])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 3: invalid — negative valuation raises ValueError
+    >>> valuations_neg = {'Alice': {'m1': -1, 'm2': 3}, 'Bob': {'m1': 4, 'm2': 6}}
+    >>> instance_neg = Instance(valuations=valuations_neg, items=['m1', 'm2'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> alloc_neg = AllocationBuilder(instance_neg)
+    >>> validate_fair_division_inputs(alloc_neg, {'c1': ['m1', 'm2']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 4: invalid — k_h too small (k_h=1 < ceil(3/2)=2) raises ValueError
+    >>> valuations_3 = {'Alice': {'m1': 5, 'm2': 3, 'm3': 1}, 'Bob': {'m1': 1, 'm2': 3, 'm3': 5}}
+    >>> instance_3 = Instance(valuations=valuations_3, items=['m1', 'm2', 'm3'], agent_capacities={'Alice': 1, 'Bob': 1})
+    >>> alloc_3 = AllocationBuilder(instance_3)
+    >>> validate_fair_division_inputs(alloc_3, {'c1': ['m1', 'm2', 'm3']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 5: invalid — item appears in two categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2'], 'c2': ['m1']}, {'Alice': {'c1': 1, 'c2': 1}, 'Bob': {'c1': 1, 'c2': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 6: invalid — an agent is missing a threshold for one of the categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, {'Alice': {'c1': 1}, 'Bob': {}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 7: invalid — duplicate agent in initial_agent_order raises ValueError
+    >>> validate_fair_division_inputs(alloc, item_categories, agent_category_capacities, ['Alice', 'Alice'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+
+    >>> # Example 8: invalid — item present in valuations but missing from all categories raises ValueError
+    >>> validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'Alice': {'c1': 1}, 'Bob': {'c1': 1}}, ['Alice', 'Bob'])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+    """
+    # --- Section: check at least one agent exists ---
+    # agents = list(alloc.instance.agents)
+    # if len(agents) == 0:
+    #     raise ValueError("No agents found in the instance.")
+
+    # --- Section: check agent_category_capacities keys match instance agents exactly ---
+    # if set(agent_category_capacities.keys()) != set(agents):
+    #     raise ValueError("agent_category_capacities agents do not match the instance agents.")
+
+    # --- Section: check initial_agent_order has no duplicates and covers all agents ---
+    # if len(initial_agent_order) != len(set(initial_agent_order)):
+    #     raise ValueError("initial_agent_order contains duplicate agents.")
+    # if set(initial_agent_order) != set(agents):
+    #     raise ValueError("initial_agent_order does not match the instance agents.")
+
+    # --- Section: check no item appears in more than one category ---
+    # all_items_in_categories = [item for items in item_categories.values() for item in items]
+    # if len(all_items_in_categories) != len(set(all_items_in_categories)):
+    #     raise ValueError("An item appears in more than one category.")
+
+    # --- Section: check every categorised item is known to the instance ---
+    # instance_items = set(alloc.instance.items)
+    # for item in all_items_in_categories:
+    #     if item not in instance_items:
+    #         raise ValueError(f"Item '{item}' in item_categories is not present in the instance.")
+
+    # --- Section: check every instance item appears in exactly one category ---
+    # categorised_items = set(all_items_in_categories)
+    # for item in instance_items:
+    #     if item not in categorised_items:
+    #         raise ValueError(f"Item '{item}' is in the instance but not assigned to any category.")
+
+    # --- Section: check all k_h values are positive integers and uniform across agents ---
+    # for category in item_categories:
+    #     capacities_for_category = []
+    #     for agent in agents:
+    #         if category not in agent_category_capacities[agent]:
+    #             raise ValueError(f"Agent '{agent}' has no threshold for category '{category}'.")
+    #         k = agent_category_capacities[agent][category]
+    #         if not isinstance(k, int) or k < 1:
+    #             raise ValueError(f"Threshold for agent '{agent}', category '{category}' must be a positive integer.")
+    #         capacities_for_category.append(k)
+    #     if len(set(capacities_for_category)) > 1:
+    #         raise ValueError(f"Thresholds for category '{category}' differ across agents (paper requires uniform k_h).")
+
+    # --- Section: check k_h >= ceil(|C_h| / n) for feasibility ---
+    # n = len(agents)
+    # for category, items in item_categories.items():
+    #     k_h = agent_category_capacities[agents[0]][category]
+    #     required = math.ceil(len(items) / n)
+    #     if k_h < required:
+    #         raise ValueError(
+    #             f"Threshold k_{category}={k_h} is too small for {len(items)} goods and {n} agents "
+    #             f"(need k_h >= ceil({len(items)}/{n}) = {required})."
+    #         )
+
+    # --- Section: check all valuations are non-negative ---
+    # for agent in agents:
+    #     for item in alloc.instance.items:
+    #         val = alloc.instance.agent_item_value(agent, item)
+    #         if val < 0:
+    #             raise ValueError(f"Valuation of agent '{agent}' for item '{item}' is negative ({val}).")
+    pass
+
+
+
+if __name__ == "__main__":
+    import doctest
+    print(doctest.testmod())

--- a/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
+++ b/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
@@ -375,16 +375,17 @@ def greedy_round_robin(
     alloc: AllocationBuilder,
     items_in_category: list,
     agent_order: list,
-    category_capacities: dict,
-    category: str,
 ) -> None:
     """
     Allocate all goods from a single category using Greedy Round-Robin (Algorithm 2).
 
     Agents pick in round-robin order, cycling repeatedly. On each turn an agent greedily
-    selects the remaining good in the category it values most, subject to its per-category
-    capacity k_h. An agent is skipped once it has received k_h goods from this category.
-    The procedure terminates when all goods are allocated or all agents have reached capacity.
+    selects the remaining good in the category it values most. The procedure terminates
+    when all goods are allocated.
+
+    No explicit capacity parameter is needed: validate_fair_division_inputs guarantees
+    k_h >= ceil(|C_h| / n) before this function is called, so the natural round-robin
+    cycling already ensures no agent receives more than k_h goods.
 
     :param alloc: an allocation builder, which tracks the allocation and the remaining
         capacity for items and agents.
@@ -392,40 +393,47 @@ def greedy_round_robin(
         in this round.
     :param agent_order: the ordered list of agents specifying the picking sequence for this
         category (either initial_agent_order or the topological sort from the previous category).
-    :param category_capacities: a dictionary mapping each category name (str) to the shared
-        integer threshold k_h for that category.
-    :param category: the name (str) of the category currently being allocated.
 
-    >>> # Example 1: 2 agents, 2 goods, k_h=1 — each agent picks their top good
+    >>> # Example 1: 2 agents, 2 goods — each agent picks their top good
     >>> from fairpyx import Instance, AllocationBuilder
     >>> valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 8}}
     >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> category_capacities = {'c1': 1}
-    >>> greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], category_capacities, 'c1')
+    >>> greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'])
     >>> alloc.sorted()
     {'Alice': ['m1'], 'Bob': ['m2']}
 
-    >>> # Example 2: 3 agents, 3 goods, k_h=1 — each picks their unique top good in order
+    >>> # Example 2: 3 agents, 3 goods — each picks their unique top good in order
     >>> valuations = {'A': {'m1': 9, 'm2': 5, 'm3': 1},
     ...               'B': {'m1': 3, 'm2': 9, 'm3': 2},
     ...               'C': {'m1': 2, 'm2': 4, 'm3': 8}}
-    >>> category_capacities = {'c1': 1}
     >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3'], ['A', 'B', 'C'], category_capacities, 'c1')
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3'], ['A', 'B', 'C'])
     >>> alloc.sorted()
     {'A': ['m1'], 'B': ['m2'], 'C': ['m3']}
 
-    >>> # Example 3: 2 agents, 4 goods, k_h=2 — each agent picks 2 goods
+    >>> # Example 3: 2 agents, 4 goods — 2 rounds, each agent picks 2 goods
     >>> valuations = {'Alice': {'m1': 10, 'm2': 8, 'm3': 5, 'm4': 3},
     ...               'Bob':   {'m1': 3,  'm2': 5, 'm3': 8, 'm4': 10}}
-    >>> category_capacities = {'c1': 2}
     >>> instance = Instance(valuations=valuations)
     >>> alloc = AllocationBuilder(instance)
-    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], category_capacities, 'c1')
+    >>> greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'])
     >>> alloc.sorted()
     {'Alice': ['m1', 'm2'], 'Bob': ['m3', 'm4']}
+
+    >>> # Example 4: competition — both agents want g1 most, but A picks first and takes it
+    >>> # Round 1: A takes g1 (value 10, best for A). B wants g1 too (value 9) but it is gone;
+    >>> #          B takes g2 instead (value 8, best remaining).
+    >>> # Round 2: A takes g3 (only remaining, value 1).
+    >>> # Result: A=[g1,g3], B=[g2]. B had to settle for its second choice.
+    >>> valuations = {'A': {'g1': 10, 'g2': 3, 'g3': 1},
+    ...               'B': {'g1': 9,  'g2': 8, 'g3': 2}}
+    >>> instance = Instance(valuations=valuations)
+    >>> alloc = AllocationBuilder(instance)
+    >>> greedy_round_robin(alloc, ['g1', 'g2', 'g3'], ['A', 'B'])
+    >>> alloc.sorted()
+    {'A': ['g1', 'g3'], 'B': ['g2']}
     """
 
     pass

--- a/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
+++ b/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
@@ -367,7 +367,6 @@ def fair_division_under_cardinality_constraints(
     # goods) are covered in full by the doctests of validate_fair_division_inputs.
     """
 
-
     pass
 
 
@@ -656,10 +655,9 @@ def validate_fair_division_inputs(
         ...
     ValueError: ...
 
-    >>> # [check 5] invalid — instance has empty valuations (no agents, no items), order is None raises ValueError
-    >>> empty_instance = Instance(valuations={})
-    >>> empty_alloc = AllocationBuilder(empty_instance)
-    >>> validate_fair_division_inputs(empty_alloc, item_categories, category_capacities, None)
+    >>> # [check 5] invalid — initial_agent_order is an empty list raises ValueError
+    >>> # (empty valuations are rejected by the fairpyx framework before reaching this function)
+    >>> validate_fair_division_inputs(alloc, item_categories, category_capacities, [])
     Traceback (most recent call last):
         ...
     ValueError: ...
@@ -838,7 +836,6 @@ def validate_fair_division_inputs(
     """
 
     pass
-
 
 if __name__ == "__main__":
     import doctest

--- a/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
+++ b/fairpyx/algorithms/fair_division_under_cardinality_constraints.py
@@ -2,7 +2,7 @@
 An implementation of the algorithm in:
 "Fair Division Under Cardinality Constraints", by A. Biswas, S. Barman (2018), https://arxiv.org/abs/1804.09521
 Programmer: Sapir Dahan
-Date : 2026-04
+Date : 2026-05
 """
 
 import math
@@ -367,7 +367,82 @@ def fair_division_under_cardinality_constraints(
     # goods) are covered in full by the doctests of validate_fair_division_inputs.
     """
 
-    pass
+    # Reject bad inputs early so the rest of the function can assume they are correct
+    validate_fair_division_inputs(alloc, item_categories, category_capacities, initial_agent_order)
+
+    # Collect all agent names from the instance
+    agents = list(alloc.instance.agents)
+
+    # Use the caller-supplied order, or fall back to alphabetical — "fix an ordering of the agents σ"
+    agent_order = initial_agent_order if initial_agent_order is not None else sorted(agents)
+
+    # Count total items so the log gives a useful overview before the loop starts
+    total_items = sum(len(v) for v in item_categories.values())
+    logger.info(
+        "Starting: %d agents, %d items total across %d categories %s",
+        len(agent_order), total_items, len(item_categories),
+        {cat: len(itms) for cat, itms in item_categories.items()},
+    )
+
+    # Convert to a list so we can check whether we are on the last category
+    categories = list(item_categories.items())
+
+    # "for h = 1 to ℓ"
+    for idx, (category, items) in enumerate(categories):
+
+        # Log the category header so each iteration is easy to spot in the output
+        logger.info(
+            "--- Category %s (%d goods) | picking order: %s ---",
+            category, len(items), agent_order,
+        )
+
+        # Log each agent's personal ranking of the goods in this category (most to least valued)
+        for agent in agent_order:
+            ranked = sorted(items, key=lambda g: alloc.instance.agent_item_value(agent, g), reverse=True)
+            logger.debug(
+                "  %s's preferences: %s",
+                agent,
+                [(g, int(alloc.instance.agent_item_value(agent, g))) for g in ranked],
+            )
+
+        # Distribute this category's goods using greedy round-robin — "B^h ← Greedy-Round-Robin(C_h, [n], (v_i)_i, σ)"
+        greedy_round_robin(alloc, items, agent_order)
+
+        # Remove any envy cycles from the current allocation by rotating bundles — "update A^h to obtain an acyclic envy graph G(A^h)"
+        G = eliminate_envy_cycles(alloc)
+
+        # Derive the picking order for the next category from the acyclic envy graph — "update σ to be a topological ordering of G(A^h)"
+        agent_order = list(nz.topological_sort(G))
+
+        # Only show the new order when there is a next category that will actually use it
+        if idx < len(categories) - 1:
+            logger.info("Picking order for next category: %s", agent_order)
+
+            # Explain each agent's position: agents nobody envies pick first (their bundle is
+            # the least desirable, so they get priority to compensate); agents many others envy
+            # pick last (they already hold the most valuable goods)
+            for rank, agent in enumerate(agent_order, 1):
+
+                # Find all agents who envy this agent (i.e. who have a directed edge pointing at them)
+                enviers = [i for i in G.nodes() if G.has_edge(i, agent)]
+
+                if enviers:
+                    # This agent's bundle is considered valuable by others, so they pick later as a penalty
+                    logger.info(
+                        "  pick %d: %s — envied by %s (their bundle is desirable → picks later)",
+                        rank, agent, enviers,
+                    )
+
+                else:
+                    # Nobody envies this agent's bundle, so they get an earlier pick as compensation.
+                    # Note: multiple agents can have no enviers — rank shows their exact position among them
+                    logger.info(
+                        "  pick %d: %s — nobody envies their bundle → gets an earlier pick (priority)",
+                        rank, agent,
+                    )
+
+    # Log the completed allocation once all categories have been processed
+    logger.info("Final allocation: %s", {a: sorted(alloc.bundles[a]) for a in alloc.instance.agents})
 
 
 def greedy_round_robin(
@@ -435,7 +510,33 @@ def greedy_round_robin(
     {'A': ['g1', 'g3'], 'B': ['g2']}
     """
 
-    pass
+    # M is the pool of items still waiting to be distributed in this category — "initialise M ← C"
+    # Using a local copy so the caller's list is never modified
+    M = list(items_in_category)
+
+    # Keep going until every item in this category has been assigned — "while M ≠ ∅"
+    while M:
+
+        # One full pass through all agents in their current picking order — "for i = 1 to n"
+        for agent in agent_order:
+
+            # All items in this category have been distributed — stop the round-robin even if
+            # some agents in the current pass have not picked yet
+            if not M:
+                break
+
+            # Each agent greedily picks the item they value most among what is still available — "argmax_{g ∈ M} v_{σ(i)}(g)"
+            best_item = max(M, key=lambda g: alloc.instance.agent_item_value(agent, g))
+
+            # Log which item was chosen and its value so picks are traceable
+            logger.debug(
+                "  Agent %s picks %s (value %g)",
+                agent, best_item, alloc.instance.agent_item_value(agent, best_item),
+            )
+
+            # Record the pick in the allocation and remove the item from the available pool — "B_{σ(i)} ← B_{σ(i)} ∪ {g}; M ← M \ {g}"
+            alloc.give(agent, best_item)
+            M.remove(best_item)
 
 
 def eliminate_envy_cycles(alloc: AllocationBuilder) -> nz.DiGraph:
@@ -515,7 +616,84 @@ def eliminate_envy_cycles(alloc: AllocationBuilder) -> nz.DiGraph:
     ['m1']
     """
 
-    return nz.DiGraph()  # placeholder so callers see a DiGraph, not None
+    # Collect all agent names once, the list stays fixed even as bundles are rotated below
+    agents = list(alloc.instance.agents)
+
+    # Repeat until the envy graph has no more cycles — "update A^h to obtain an acyclic envy graph G(A^h)"
+    # Each iteration either eliminates one cycle (and restarts) or confirms the graph is a DAG (and exits)
+    while True:
+
+        # Build a fresh directed graph from scratch — bundles may have changed in the previous iteration
+        G = nz.DiGraph()
+
+        # Every agent must be a node even if nobody envies them, so topological sort sees all agents later
+        G.add_nodes_from(agents)
+
+        # Check every ordered pair (i, j) to decide whether agent i envies agent j
+        for i in agents:
+
+            # How much agent i values their own current bundle (sum of item values)
+            val_i_own = alloc.instance.agent_bundle_value(i, alloc.bundles[i])
+
+            for j in agents:
+
+                # An agent cannot envy themselves, so skip the same-agent pair
+                if i == j:
+                    continue
+
+                # How much agent i would value j's bundle if they had it instead
+                val_i_other = alloc.instance.agent_bundle_value(i, alloc.bundles[j])
+
+                if val_i_other > val_i_own:
+
+                    # i strictly prefer j's bundle — this is the definition of envy, so add edge i → j
+                    G.add_edge(i, j)
+                    logger.debug(
+                        "  %s envies %s  (%s values own bundle=%g < %s's bundle=%g)",
+                        i, j, i, val_i_own, j, val_i_other,
+                    )
+
+        # Build a readable summary of who envies whom and log it at INFO level
+        if G.edges():
+            envy_desc = ",  ".join(f"{i} envies {j}" for i, j in G.edges())
+            logger.info("Envy: %s", envy_desc)
+
+        else:
+            # No edges means no agent envies any other — allocation is already envy-free
+            logger.info("No envy — all agents prefer their own bundle")
+
+        # Try to find one directed cycle in the envy graph; we only need one per iteration
+        # nz.simple_cycles returns a generator — next() takes the first cycle or None if none exist
+        cycle = next(nz.simple_cycles(G), None)
+
+        if cycle is None:
+
+            # No cycle found — the graph is a DAG, so we are done
+            logger.info("Envy graph is a DAG — no cycles, moving on")
+            break
+
+        # Format the cycle as "a → b → c → a" to make the direction clear in the log
+        cycle_str = " -> ".join(cycle) + " -> " + cycle[0]
+        logger.info("Cycle detected: %s  — rotating bundles along cycle", cycle_str)
+
+        # Snapshot every bundle in the cycle BEFORE any assignment, because we are about to
+        # overwrite alloc.bundles entries and would otherwise lose the original values mid-rotation
+        saved = {agent: alloc.bundles[agent] for agent in cycle}
+
+        # Rotate: each agent at position idx receives the bundle of the agent at position idx+1
+        # The modulo wraps the last agent back to position 0, giving the last agent the first agent's bundle
+        # a_1 ← a_2's bundle, a_2 ← a_3's bundle, ..., a_r ← a_1's bundle
+        for idx in range(len(cycle)):
+            alloc.bundles[cycle[idx]] = saved[cycle[(idx + 1) % len(cycle)]]
+
+        # Log the full allocation after the rotation so the effect on every agent is visible
+        logger.info(
+            "After rotation: %s",
+            {a: sorted(alloc.bundles[a]) for a in alloc.bundles},
+        )
+
+    # Return the final acyclic envy graph so the caller can run topological sort to get the next picking order
+    return G
 
 
 
@@ -835,8 +1013,165 @@ def validate_fair_division_inputs(
     >>> validate_fair_division_inputs(alloc_3, {'c1': ['m1', 'm2', 'm3']}, {'c1': 2}, ['Alice', 'Bob'])
     """
 
-    pass
+    logger.debug("Validating inputs: %d agents, %d categories", len(list(alloc.instance.agents)), len(item_categories) if isinstance(item_categories, dict) else "?")
+
+    # Check 1: initial_agent_order must be None or a list
+    if initial_agent_order is not None and not isinstance(initial_agent_order, list):
+        logger.warning("Check 1 failed: initial_agent_order is %s, expected None or list", type(initial_agent_order).__name__)
+        raise ValueError(
+            f"initial_agent_order must be None or a list, got {type(initial_agent_order).__name__}"
+        )
+
+    # Check 2: item_categories must be a dict
+    if not isinstance(item_categories, dict):
+        logger.warning("Check 2 failed: item_categories is %s, expected dict", type(item_categories).__name__)
+        raise ValueError(
+            f"item_categories must be a dict, got {type(item_categories).__name__}"
+        )
+
+    # Check 3: category_capacities must be a dict
+    if not isinstance(category_capacities, dict):
+        logger.warning("Check 3 failed: category_capacities is %s, expected dict", type(category_capacities).__name__)
+        raise ValueError(
+            f"category_capacities must be a dict, got {type(category_capacities).__name__}"
+        )
+
+    # Check 4: every value in item_categories must be a list
+    for cat, cat_items in item_categories.items():
+        if not isinstance(cat_items, list):
+            logger.warning("Check 4 failed: item_categories[%r] is %s, expected list", cat, type(cat_items).__name__)
+            raise ValueError(
+                f"item_categories[{cat!r}] must be a list, got {type(cat_items).__name__}"
+            )
+
+    # Check 5: at least one agent (fires when initial_agent_order=[] is passed)
+    agents_to_use = initial_agent_order if initial_agent_order is not None else list(alloc.instance.agents)
+    if len(agents_to_use) == 0:
+        logger.warning("Check 5 failed: no agents provided")
+        raise ValueError("At least one agent must exist in the instance")
+
+    # Check 6: at least one category
+    if len(item_categories) == 0:
+        logger.warning("Check 6 failed: item_categories is empty")
+        raise ValueError("item_categories must contain at least one category")
+
+    # Check 7: no empty category lists
+    for cat, cat_items in item_categories.items():
+        if len(cat_items) == 0:
+            logger.warning("Check 7 failed: category %r has an empty item list", cat)
+            raise ValueError(f"Category {cat!r} has an empty item list")
+
+    # Check 8: if provided, initial_agent_order must be an exact permutation of the agents
+    if initial_agent_order is not None:
+        instance_agents = set(alloc.instance.agents)
+        order_set = set(initial_agent_order)
+        if len(initial_agent_order) != len(order_set) or order_set != instance_agents:
+            logger.warning("Check 8 failed: initial_agent_order %s is not a permutation of agents %s", initial_agent_order, sorted(instance_agents))
+            raise ValueError(
+                f"initial_agent_order must be a permutation of the agents. "
+                f"Got {initial_agent_order}, expected {sorted(instance_agents)}"
+            )
+
+    # Check 9: category_capacities keys must match item_categories keys exactly
+    if set(category_capacities.keys()) != set(item_categories.keys()):
+        logger.warning("Check 9 failed: category_capacities keys %s != item_categories keys %s", set(category_capacities.keys()), set(item_categories.keys()))
+        raise ValueError(
+            f"category_capacities keys {set(category_capacities.keys())} must match "
+            f"item_categories keys {set(item_categories.keys())}"
+        )
+
+    # Check 10: every item listed in item_categories must exist in the instance
+    instance_items = set(alloc.instance.items)
+    for cat, cat_items in item_categories.items():
+        for item in cat_items:
+            if item not in instance_items:
+                logger.warning("Check 10 failed: item %r in category %r does not exist in the instance", item, cat)
+                raise ValueError(
+                    f"Item {item!r} in category {cat!r} does not exist in the instance"
+                )
+
+    # Check 11: every item in the instance must appear in at least one category
+    all_categorised = set(item for cat_items in item_categories.values() for item in cat_items)
+    for item in alloc.instance.items:
+        if item not in all_categorised:
+            logger.warning("Check 11 failed: item %r is in the instance but not in any category", item)
+            raise ValueError(
+                f"Item {item!r} exists in the instance but is not listed in any category"
+            )
+
+    # Check 12: no item may appear in more than one category
+    seen_items: set = set()
+    for cat, cat_items in item_categories.items():
+        for item in cat_items:
+            if item in seen_items:
+                logger.warning("Check 12 failed: item %r appears in more than one category", item)
+                raise ValueError(f"Item {item!r} appears in more than one category")
+            seen_items.add(item)
+
+    # Check 13: all valuation values must be non-negative
+    for agent in alloc.instance.agents:
+        for item in alloc.instance.items:
+            if alloc.instance.agent_item_value(agent, item) < 0:
+                logger.warning("Check 13 failed: agent %r has negative valuation for item %r", agent, item)
+                raise ValueError(
+                    f"Valuation of agent {agent!r} for item {item!r} is negative"
+                )
+
+    # Check 14: all k_h must be positive integers (bool is excluded: isinstance(True, int) is True)
+    for cat, k_h in category_capacities.items():
+        if isinstance(k_h, bool) or not isinstance(k_h, int) or k_h <= 0:
+            logger.warning("Check 14 failed: category_capacities[%r] = %r is not a positive integer", cat, k_h)
+            raise ValueError(
+                f"category_capacities[{cat!r}] = {k_h!r} must be a positive integer"
+            )
+
+    # Check 15: k_h >= ceil(|C_h| / n) — feasibility condition from the paper
+    n = len(list(alloc.instance.agents))
+    for cat, cat_items in item_categories.items():
+        k_h = category_capacities[cat]
+        min_required = math.ceil(len(cat_items) / n)
+        if k_h < min_required:
+            logger.warning("Check 15 failed: category %r has k_h=%d < ceil(%d/%d)=%d — feasibility violated", cat, k_h, len(cat_items), n, min_required)
+            raise ValueError(
+                f"category_capacities[{cat!r}] = {k_h} < ceil({len(cat_items)}/{n}) = {min_required}. "
+                f"The feasibility condition k_h >= ceil(|C_h|/n) is violated."
+            )
+
+    logger.debug("All 15 validation checks passed")
 
 if __name__ == "__main__":
-    import doctest
-    print(doctest.testmod())
+    # Demo: run the algorithm on Example 10 (3 agents, 6 goods, 2 categories, k_h=1).
+    # This example produces two overlapping envy cycles after C2, showing the full cycle-elimination logic.
+    import logging
+    from fairpyx import divide
+
+    logging.basicConfig(
+        level=logging.DEBUG,   # change to INFO to hide per-pick detail
+        format="%(levelname)-5s  %(name)s: %(message)s",
+    )
+
+    valuations = {
+        'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
+        'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
+        'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
+    }
+    item_categories = {'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']}
+    category_capacities = {'C1': 1, 'C2': 1}
+
+    instance = Instance(valuations=valuations)
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=instance,
+        item_categories=item_categories,
+        category_capacities=category_capacities,
+        initial_agent_order=['a1', 'a2', 'a3'],
+    )
+
+    # Validation failure demo: k_h=0 violates check 14 — a WARNING is logged before the ValueError
+    print("\n--- Validation failure demo ---")
+    from fairpyx import AllocationBuilder
+    bad_alloc = AllocationBuilder(instance)
+    try:
+        validate_fair_division_inputs(bad_alloc, item_categories, {'C1': 0, 'C2': 1}, ['a1', 'a2', 'a3'])
+    except ValueError as e:
+        print("Caught ValueError:", e)

--- a/tests/test_fair_division_under_cardinality_constraints.py
+++ b/tests/test_fair_division_under_cardinality_constraints.py
@@ -167,187 +167,6 @@ def random_valid_instance(num_agents, num_items, num_categories, seed):
 # Section 1: fair_division_under_cardinality_constraints (Algorithm 1)
 # ---------------------------------------------------------------------------
 
-def test_algorithm1_doctest_instances():
-    """Replicate the doctest examples 1-10 with exact expected outputs."""
-
-    # Example 1: basic — 2 agents, 2 categories, k_h=1
-    valuations = {
-        'Agent1': {'m1': 9, 'm2': 3, 'm3': 8, 'm4': 2},
-        'Agent2': {'m1': 3, 'm2': 9, 'm3': 2, 'm4': 8},
-    }
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations),
-        item_categories={'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']},
-        category_capacities={'c1': 1, 'c2': 1},
-        initial_agent_order=['Agent1', 'Agent2'],
-    )
-    assert result == {'Agent1': ['m1', 'm3'], 'Agent2': ['m2', 'm4']}
-
-    # Example 2: 3 agents, 2 categories of 3 goods each, k_h=1
-    valuations = {
-        'Agent1': {'m1': 9, 'm2': 6, 'm3': 3, 'm4': 8, 'm5': 5, 'm6': 2},
-        'Agent2': {'m1': 3, 'm2': 9, 'm3': 6, 'm4': 2, 'm5': 8, 'm6': 5},
-        'Agent3': {'m1': 6, 'm2': 3, 'm3': 9, 'm4': 5, 'm5': 2, 'm6': 8},
-    }
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations),
-        item_categories={'c1': ['m1', 'm2', 'm3'], 'c2': ['m4', 'm5', 'm6']},
-        category_capacities={'c1': 1, 'c2': 1},
-        initial_agent_order=['Agent1', 'Agent2', 'Agent3'],
-    )
-    assert result == {'Agent1': ['m1', 'm4'], 'Agent2': ['m2', 'm5'], 'Agent3': ['m3', 'm6']}
-
-    # Example 3: single agent — trivially receives all goods
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations={'Alice': {'m1': 10, 'm2': 7, 'm3': 4}}),
-        item_categories={'c1': ['m1', 'm2', 'm3']},
-        category_capacities={'c1': 3},
-        initial_agent_order=['Alice'],
-    )
-    assert result == {'Alice': ['m1', 'm2', 'm3']}
-
-    # Example 4: single category — greedy_round_robin only, k_h=2
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations={'A': {'x': 10, 'y': 5, 'z': 1}, 'B': {'x': 1, 'y': 5, 'z': 10}}),
-        item_categories={'c1': ['x', 'y', 'z']},
-        category_capacities={'c1': 2},
-        initial_agent_order=['A', 'B'],
-    )
-    assert result == {'A': ['x', 'y'], 'B': ['z']}
-
-    # Example 5: single good per category — envy after c1 reverses order for c2
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations={'Agent1': {'m1': 8, 'm2': 5}, 'Agent2': {'m1': 5, 'm2': 8}}),
-        item_categories={'c1': ['m1'], 'c2': ['m2']},
-        category_capacities={'c1': 1, 'c2': 1},
-        initial_agent_order=['Agent1', 'Agent2'],
-    )
-    assert result == {'Agent1': ['m1'], 'Agent2': ['m2']}
-
-    # Example 6: asymmetric category sizes
-    valuations = {
-        'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4, 'm5': 9},
-        'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10, 'm5': 7},
-    }
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations),
-        item_categories={'c1': ['m1', 'm2', 'm3', 'm4'], 'c2': ['m5']},
-        category_capacities={'c1': 2, 'c2': 1},
-        initial_agent_order=['Agent1', 'Agent2'],
-    )
-    assert result == {'Agent1': ['m1', 'm2', 'm5'], 'Agent2': ['m3', 'm4']}
-
-    # Example 7: minimal base case — 1 agent, 1 good
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations={'a1': {'g1': 2}}),
-        item_categories={'C1': ['g1']},
-        category_capacities={'C1': 1},
-        initial_agent_order=['a1'],
-    )
-    assert result == {'a1': ['g1']}
-
-    # Example 8: 2 agents, 2 goods, 1 category, k_h=1
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations={'a1': {'g1': 2, 'g2': 3}, 'a2': {'g1': 1, 'g2': 4}}),
-        item_categories={'C1': ['g1', 'g2']},
-        category_capacities={'C1': 1},
-        initial_agent_order=['a1', 'a2'],
-    )
-    assert result == {'a1': ['g2'], 'a2': ['g1']}
-
-    # Example 9: 2 agents, 6 goods, 2 categories, k_h=2 — order reverses for C2
-    valuations = {
-        'a1': {'g1': 9, 'g2': 6, 'g3': 3, 'g4': 8, 'g5': 5, 'g6': 2},
-        'a2': {'g1': 4, 'g2': 7, 'g3': 8, 'g4': 3, 'g5': 9, 'g6': 6},
-    }
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations),
-        item_categories={'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']},
-        category_capacities={'C1': 2, 'C2': 2},
-        initial_agent_order=['a1', 'a2'],
-    )
-    assert result == {'a1': ['g1', 'g2', 'g4'], 'a2': ['g3', 'g5', 'g6']}
-
-    # Example 10: 3 agents, 6 goods, 2 categories — multiple overlapping cycles
-    valuations = {
-        'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
-        'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
-        'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
-    }
-    result = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations),
-        item_categories={'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']},
-        category_capacities={'C1': 1, 'C2': 1},
-        initial_agent_order=['a1', 'a2', 'a3'],
-    )
-    assert result == {'a1': ['g2', 'g5'], 'a2': ['g3', 'g4'], 'a3': ['g1', 'g6']}
-
-    # Example 11: 4 agents, 26 goods, 4 categories, k_h=2 (large instance from the paper)
-    # The topological sort uses lex secondary sort (by agent name), making the output fully
-    # deterministic. Once the implementation runs, replace the property checks below with
-    # an exact assertion (assert result11 == {...}).
-    # For now we verify the three core guarantees:
-    valuations_11 = {
-        'a1': {'g1':9,'g2':4,'g3':8,'g4':1,'g5':6,'g6':2,'g7':10,'g8':3,'g9':5,'g10':1,'g11':7,
-               'g12':6,'g13':2,'g14':9,'g15':4,'g16':8,'g17':1,'g18':3,
-               'g19':5,'g20':7,'g21':2,'g22':10,'g23':4,'g24':6,'g25':1,'g26':8},
-        'a2': {'g1':3,'g2':10,'g3':2,'g4':7,'g5':5,'g6':9,'g7':1,'g8':8,'g9':4,'g10':6,'g11':2,
-               'g12':1,'g13':7,'g14':3,'g15':10,'g16':5,'g17':8,'g18':4,
-               'g19':6,'g20':2,'g21':9,'g22':1,'g23':7,'g24':3,'g25':10,'g26':5},
-        'a3': {'g1':8,'g2':1,'g3':5,'g4':9,'g5':2,'g6':4,'g7':6,'g8':10,'g9':1,'g10':7,'g11':3,
-               'g12':9,'g13':5,'g14':2,'g15':6,'g16':1,'g17':10,'g18':4,
-               'g19':8,'g20':3,'g21':6,'g22':2,'g23':9,'g24':1,'g25':5,'g26':7},
-        'a4': {'g1':2,'g2':6,'g3':10,'g4':3,'g5':7,'g6':5,'g7':2,'g8':1,'g9':10,'g10':8,'g11':4,
-               'g12':3,'g13':9,'g14':6,'g15':2,'g16':7,'g17':5,'g18':10,
-               'g19':1,'g20':8,'g21':4,'g22':6,'g23':2,'g24':10,'g25':3,'g26':9},
-    }
-    item_categories_11 = {
-        'C1': ['g1','g2','g3','g4','g5'],
-        'C2': ['g6','g7','g8','g9','g10','g11'],
-        'C3': ['g12','g13','g14','g15','g16','g17','g18'],
-        'C4': ['g19','g20','g21','g22','g23','g24','g25','g26'],
-    }
-    category_capacities_11 = {'C1': 2, 'C2': 2, 'C3': 2, 'C4': 2}
-    all_goods_11 = [f'g{i}' for i in range(1, 27)]
-    result11 = divide(
-        algorithm=fair_division_under_cardinality_constraints,
-        instance=Instance(valuations=valuations_11),
-        item_categories=item_categories_11,
-        category_capacities=category_capacities_11,
-        initial_agent_order=['a1', 'a2', 'a3', 'a4'],
-    )
-    assert sorted(g for bundle in result11.values() for g in bundle) == sorted(all_goods_11), \
-        "Example 11: not all 26 goods were allocated"
-    assert check_cardinality_constraints(result11, item_categories_11, category_capacities_11), \
-        f"Example 11: cardinality constraint violated. result={result11}"
-    assert check_ef1(result11, valuations_11), \
-        f"Example 11: EF1 violated. result={result11}"
-    # Exact output — hand-traced (no value ties anywhere, fully deterministic):
-    # C1 σ=['a1','a2','a3','a4']: a1←g1,g5  a2←g2  a3←g4  a4←g3
-    # Envy after C1: a3→a1 only. Topo sort → ['a2','a3','a4','a1']
-    # C2 σ=['a2','a3','a4','a1']: a2←g6,g10  a3←g8,g11  a4←g9  a1←g7
-    # No envy after C2. Topo sort → ['a1','a2','a3','a4']
-    # C3 σ=['a1','a2','a3','a4']: a1←g14,g16  a2←g15,g13  a3←g17,g12  a4←g18
-    # No envy after C3. Topo sort → ['a1','a2','a3','a4']
-    # C4 σ=['a1','a2','a3','a4']: a1←g22,g26  a2←g25,g21  a3←g23,g19  a4←g24,g20
-    assert result11 == {
-        'a1': ['g1', 'g14', 'g16', 'g22', 'g26', 'g5', 'g7'],
-        'a2': ['g10', 'g13', 'g15', 'g2', 'g21', 'g25', 'g6'],
-        'a3': ['g11', 'g12', 'g17', 'g19', 'g23', 'g4', 'g8'],
-        'a4': ['g18', 'g20', 'g24', 'g3', 'g9'],
-    }
-
-
 def test_algorithm1_all_goods_allocated():
     """Every good appears in exactly one bundle (no omissions, no duplicates)."""
     for i in range(NUM_OF_RANDOM_INSTANCES):
@@ -378,7 +197,7 @@ def test_algorithm1_cardinality_constraints():
     """No agent receives more than k_h goods from any category."""
     for i in range(NUM_OF_RANDOM_INSTANCES):
         valuations, item_categories, category_capacities, agent_order = random_valid_instance(
-            num_agents=3, num_items=15, num_categories=2, seed=i * 13
+            num_agents=4, num_items=20, num_categories=3, seed=i * 13
         )
         instance = Instance(valuations=valuations)
         result = divide(
@@ -446,14 +265,31 @@ def test_algorithm1_default_order():
 
 def test_algorithm1_topo_order_influences_next_category():
     """
-    Example 9: after C1, a2 envies a1 (envy graph: a2→a1).
-    Topo sort gives σ = ['a2', 'a1'] for C2, so a2 picks first in C2.
-    a2 values C2 goods as: g4=3, g5=9, g6=6 → picks g5 (value 9) first.
-    Verify a2's C2 allocation contains g5, proving topo sort influenced picking order.
+    Verify that the topological sort of the envy graph after C1 actually changes
+    who picks first in C2, and that this change affects the outcome.
+
+    Setup:
+      C1 round-robin σ=['a1','a2'], k_h=2 (3 goods):
+        a1 picks g1 (value 9), a2 picks g2 (value 8), a1 picks g3 (only remaining).
+      After C1: a1=[g1,g3], a2=[g2].
+
+      Envy check:
+        v_a2(a1's bundle) = 7+2 = 9  >  v_a2(a2's bundle) = 8  → a2 envies a1. Edge: a2→a1.
+      No cycle → topo sort gives σ = ['a2','a1'] for C2.
+
+      C2 round-robin σ=['a2','a1'], k_h=2 (3 goods):
+        a2 picks g4 (its top C2 good, value 9).
+        a1 picks g5 (best remaining for a1: value 3).
+        a2 picks g6 (only remaining, value 1).
+
+    The key: BOTH agents rank g4 as their top C2 good (a1 values it 10, a2 values it 9).
+    If a1 had gone first (original order), a1 would have taken g4.
+    Because a2 envied a1, topo sort put a2 first → a2 gets g4 instead.
+    This proves the order change had a concrete effect on the allocation.
     """
     valuations = {
-        'a1': {'g1': 9, 'g2': 6, 'g3': 3, 'g4': 8, 'g5': 5, 'g6': 2},
-        'a2': {'g1': 4, 'g2': 7, 'g3': 8, 'g4': 3, 'g5': 9, 'g6': 6},
+        'a1': {'g1': 9, 'g2': 6, 'g3': 1, 'g4': 10, 'g5': 3, 'g6': 2},
+        'a2': {'g1': 7, 'g2': 8, 'g3': 2, 'g4': 9,  'g5': 4, 'g6': 1},
     }
     instance = Instance(valuations=valuations)
     result = divide(
@@ -463,14 +299,15 @@ def test_algorithm1_topo_order_influences_next_category():
         category_capacities={'C1': 2, 'C2': 2},
         initial_agent_order=['a1', 'a2'],
     )
-    # a2 picked first in C2 (due to topo sort) → a2 must have g5 (a2's top C2 good, value 9)
-    assert 'g5' in result['a2'], (
-        f"Expected a2 to get g5 (top C2 good) since a2 envies a1 after C1 → picks first in C2. "
-        f"Got: a2={result['a2']}"
+    # a2 picked first in C2 (topo sort) → a2 must have g4 (top C2 good for both agents).
+    # If a1 had gone first, a1 would have taken g4 (a1 values it at 10, its personal best in C2).
+    assert 'g4' in result['a2'], (
+        f"Expected a2 to get g4 (top C2 good for both agents) since a2 envies a1 after C1 "
+        f"→ topo sort puts a2 first in C2. Got: a2={result['a2']}"
     )
-    # a1 should have gotten its best remaining C2 good: g4 (value 8) after a2 took g5
-    assert 'g4' in result['a1'], (
-        f"Expected a1 to get g4 after a2 took g5. Got: a1={result['a1']}"
+    # a1 was pushed to second pick in C2 → a1 gets g5 (best remaining after g4 is taken).
+    assert 'g4' not in result['a1'], (
+        f"a1 should NOT have g4: topo sort gave a2 the first pick. Got: a1={result['a1']}"
     )
 
 
@@ -483,7 +320,7 @@ def test_greedy_picks_top_good():
     valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 8}}
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
-    greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], {'c1': 1}, 'c1')
+    greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'])
     assert alloc.sorted() == {'Alice': ['m1'], 'Bob': ['m2']}
 
 
@@ -495,7 +332,7 @@ def test_greedy_multiple_rounds():
     }
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
-    greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], {'c1': 2}, 'c1')
+    greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'])
     assert alloc.sorted() == {'Alice': ['m1', 'm2'], 'Bob': ['m3', 'm4']}
 
 
@@ -509,7 +346,7 @@ def test_greedy_partial_rounds():
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
     # Only 2 goods, 3 agents, k_h=1 → only first 2 agents in order get a good
-    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B', 'C'], {'c1': 1}, 'c1')
+    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B', 'C'])
     sorted_result = alloc.sorted()
     # Both g1 and g2 must be allocated
     allocated = [g for bundle in sorted_result.values() for g in bundle]
@@ -526,10 +363,9 @@ def test_greedy_all_goods_allocated():
         agents = [f"a{j}" for j in range(1, n + 1)]
         goods = [f"g{j}" for j in range(1, m + 1)]
         valuations = {a: {g: int(rng.integers(1, 15)) for g in goods} for a in agents}
-        k_h = math.ceil(m / n)
         instance = Instance(valuations=valuations)
         alloc = AllocationBuilder(instance)
-        greedy_round_robin(alloc, goods, agents, {'c1': k_h}, 'c1')
+        greedy_round_robin(alloc, goods, agents)
         allocated = sorted([g for bundle in alloc.bundles.values() for g in bundle])
         assert allocated == sorted(goods), f"Seed {i * 5}: not all goods allocated"
 
@@ -544,11 +380,11 @@ def test_greedy_respects_order():
     instance = Instance(valuations=valuations)
 
     alloc1 = AllocationBuilder(instance)
-    greedy_round_robin(alloc1, ['x', 'y'], ['A', 'B'], {'c1': 1}, 'c1')
+    greedy_round_robin(alloc1, ['x', 'y'], ['A', 'B'])
     assert 'x' in alloc1.bundles['A']  # A is first, gets x
 
     alloc2 = AllocationBuilder(instance)
-    greedy_round_robin(alloc2, ['x', 'y'], ['B', 'A'], {'c1': 1}, 'c1')
+    greedy_round_robin(alloc2, ['x', 'y'], ['B', 'A'])
     assert 'x' in alloc2.bundles['B']  # B is first, gets x
 
 
@@ -557,7 +393,7 @@ def test_greedy_tied_valuations():
     valuations = {'A': {'g1': 5, 'g2': 5}, 'B': {'g1': 5, 'g2': 5}}
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
-    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B'], {'c1': 1}, 'c1')
+    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B'])
     allocated = sorted([g for bundle in alloc.bundles.values() for g in bundle])
     assert allocated == ['g1', 'g2']
 
@@ -571,10 +407,16 @@ def test_eliminate_no_cycle():
     valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 9}}
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
+    # Alice has m1, Bob has m2 — each holds the good they value most.
     alloc.give('Alice', 'm1')
     alloc.give('Bob', 'm2')
+    # Envy check:
+    #   Alice values own bundle=9, Bob's bundle=3 → Alice does NOT envy Bob.
+    #   Bob   values own bundle=9, Alice's bundle=3 → Bob   does NOT envy Alice.
+    # No edges → graph is already a DAG. No cycle to eliminate.
     G = eliminate_envy_cycles(alloc)
     assert list(nz.simple_cycles(G)) == []
+    # Bundles must be untouched — no rotation happened.
     assert sorted(alloc.bundles['Alice']) == ['m1']
     assert sorted(alloc.bundles['Bob']) == ['m2']
 
@@ -584,8 +426,15 @@ def test_eliminate_2agent_cycle():
     valuations = {'Alice': {'m1': 3, 'm2': 7}, 'Bob': {'m1': 7, 'm2': 3}}
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
+    # Alice has m1 (she values at 3), Bob has m2 (he values at 3).
     alloc.give('Alice', 'm1')
     alloc.give('Bob', 'm2')
+    # Envy check:
+    #   Alice values own bundle=3, Bob's bundle=7  → Alice ENVIES Bob. Edge: Alice→Bob.
+    #   Bob   values own bundle=3, Alice's bundle=7 → Bob   ENVIES Alice. Edge: Bob→Alice.
+    # Cycle detected: Alice→Bob→Alice.
+    # Rotation: Alice receives Bob's bundle, Bob receives Alice's bundle (swap).
+    # After swap: Alice has m2 (value 7), Bob has m1 (value 7) — no more envy.
     G = eliminate_envy_cycles(alloc)
     assert list(nz.simple_cycles(G)) == []
     assert sorted(alloc.bundles['Alice']) == ['m2']
@@ -601,9 +450,17 @@ def test_eliminate_3agent_cycle():
     }
     instance = Instance(valuations=valuations)
     alloc = AllocationBuilder(instance)
+    # Initial assignment: A has m1, B has m2, C has m3.
     alloc.give('A', 'm1')
     alloc.give('B', 'm2')
     alloc.give('C', 'm3')
+    # Envy check:
+    #   A values own=3, B's=5, C's=1 → A ENVIES B. Edge: A→B.
+    #   B values own=3, A's=1, C's=5 → B ENVIES C. Edge: B→C.
+    #   C values own=3, A's=5, B's=1 → C ENVIES A. Edge: C→A.
+    # Cycle detected: A→B→C→A.
+    # Rotation along the cycle: A←B's bundle, B←C's bundle, C←A's bundle.
+    # After rotation: A has m2 (value 5), B has m3 (value 5), C has m1 (value 5) — no envy.
     G = eliminate_envy_cycles(alloc)
     assert list(nz.simple_cycles(G)) == []
     assert sorted(alloc.bundles['A']) == ['m2']
@@ -615,17 +472,20 @@ def test_eliminate_result_is_dag():
     """After eliminate_envy_cycles, the returned graph always has no directed cycles."""
     for i in range(NUM_OF_RANDOM_INSTANCES):
         rng = np.random.default_rng(i * 3)
-        n, m = 4, 8
+        n, m = 10, 30
         agents = [f"a{j}" for j in range(1, n + 1)]
         goods = [f"g{j}" for j in range(1, m + 1)]
         valuations = {a: {g: int(rng.integers(0, 15)) for g in goods} for a in agents}
         instance = Instance(valuations=valuations)
         alloc = AllocationBuilder(instance)
-        # Assign goods randomly to agents
+        # Distribute goods round-robin style (idx % n) to create arbitrary, potentially
+        # envy-heavy allocations — this maximises the chance of generating cycles.
         shuffled = list(goods)
         rng.shuffle(shuffled)
         for idx, good in enumerate(shuffled):
             alloc.give(agents[idx % n], good)
+        # The paper guarantees eliminate_envy_cycles always produces a DAG.
+        # We verify this holds for every random allocation.
         G = eliminate_envy_cycles(alloc)
         assert list(nz.simple_cycles(G)) == [], f"Seed {i * 3}: cycle found in result graph"
 
@@ -634,60 +494,35 @@ def test_eliminate_no_value_decrease():
     """Lemma 1: after cycle elimination, no agent's total valuation decreases."""
     for i in range(NUM_OF_RANDOM_INSTANCES):
         rng = np.random.default_rng(i * 11)
-        n, m = 4, 8
+        n, m = 10, 30
         agents = [f"a{j}" for j in range(1, n + 1)]
         goods = [f"g{j}" for j in range(1, m + 1)]
         valuations = {a: {g: int(rng.integers(0, 15)) for g in goods} for a in agents}
         instance = Instance(valuations=valuations)
         alloc = AllocationBuilder(instance)
+        # Same arbitrary distribution as test_eliminate_result_is_dag.
         shuffled = list(goods)
         rng.shuffle(shuffled)
         for idx, good in enumerate(shuffled):
             alloc.give(agents[idx % n], good)
-        # Record values before
+        # Snapshot each agent's total value before any cycle elimination.
         value_before = {
             a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
             for a in agents
         }
         eliminate_envy_cycles(alloc)
+        # Snapshot each agent's total value after cycle elimination.
         value_after = {
             a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
             for a in agents
         }
+        # Lemma 1: rotating bundles along an envy cycle never
+        # reduces any agent's utility — each agent in the cycle receives a bundle it
+        # envied, so its value can only stay the same or increase.
         for a in agents:
             assert value_after[a] >= value_before[a], (
                 f"Seed {i * 11}: agent {a} value decreased from {value_before[a]} to {value_after[a]}"
             )
-
-
-def test_eliminate_complex_overlapping():
-    """
-    Example 10 (after C2, before final cycle elimination):
-    Initial bundles: a1=[g2,g5], a2=[g1,g6], a3=[g3,g4].
-    Envy edges: a1→a2, a2→a1, a2→a3, a3→a1 (two overlapping cycles).
-    After elimination, result must be a DAG with the final EF1 bundles.
-    """
-    valuations = {
-        'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
-        'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
-        'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
-    }
-    instance = Instance(valuations=valuations)
-    alloc = AllocationBuilder(instance)
-    # Set up bundles directly to mirror the state after C2 round-robin
-    for g in ['g2', 'g5']:
-        alloc.give('a1', g)
-    for g in ['g1', 'g6']:
-        alloc.give('a2', g)
-    for g in ['g3', 'g4']:
-        alloc.give('a3', g)
-    G = eliminate_envy_cycles(alloc)
-    assert list(nz.simple_cycles(G)) == []
-    # Both valid elimination paths lead to the same allocation
-    assert sorted(alloc.bundles['a1']) == ['g2', 'g5']
-    assert sorted(alloc.bundles['a2']) == ['g3', 'g4']
-    assert sorted(alloc.bundles['a3']) == ['g1', 'g6']
-
 
 # ---------------------------------------------------------------------------
 # Section 4: validate_fair_division_inputs
@@ -698,123 +533,286 @@ def _make_alloc(valuations):
     return AllocationBuilder(Instance(valuations=valuations))
 
 
-def test_validate_valid_inputs():
-    """Valid inputs do not raise any exception."""
+def test_validate_check1_agent_order_type():
+    """Check 1: initial_agent_order must be None or a list — any other type raises ValueError."""
+    alloc = _make_alloc({'X': {'g1': 5, 'g2': 3}, 'Y': {'g1': 3, 'g2': 7}})
+    item_categories = {'c1': ['g1', 'g2']}
+    category_capacities = {'c1': 1}
+
+    # Valid: None is explicitly allowed (defaults to sorted agents)
+    validate_fair_division_inputs(alloc, item_categories, category_capacities, None)  # must not raise
+    # Valid: a list is the correct type
+    validate_fair_division_inputs(alloc, item_categories, category_capacities, ['X', 'Y'])  # must not raise
+
+    # Invalid: tuple looks like a list but is a different type
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, ('X', 'Y'))
+    # Invalid: set has no defined order and is not a list
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, {'X', 'Y'})
+    # Invalid: integer is clearly wrong
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, 42)
+
+
+def test_validate_check2_item_categories_type():
+    """Check 2: item_categories must be a dict — any other type raises ValueError."""
+    alloc = _make_alloc({'A': {'g1': 4, 'g2': 6}, 'B': {'g1': 6, 'g2': 4}})
+    category_capacities = {'c1': 1}
+
+    # Invalid: list of tuples is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, [('c1', ['g1', 'g2'])], category_capacities, ['A', 'B'])
+    # Invalid: None is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, None, category_capacities, ['A', 'B'])
+    # Invalid: a plain string is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, 'c1', category_capacities, ['A', 'B'])
+
+
+def test_validate_check3_category_capacities_type():
+    """Check 3: category_capacities must be a dict — any other type raises ValueError."""
+    alloc = _make_alloc({'P': {'x': 2, 'y': 8}, 'Q': {'x': 8, 'y': 2}})
+    item_categories = {'c1': ['x', 'y']}
+
+    # Invalid: list of tuples is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, [('c1', 1)], ['P', 'Q'])
+    # Invalid: None is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, None, ['P', 'Q'])
+    # Invalid: integer is not a dict
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, 1, ['P', 'Q'])
+
+
+def test_validate_check4_category_values_are_lists():
+    """Check 4: every value in item_categories must be a list — tuple or set raises ValueError."""
+    alloc = _make_alloc({'A': {'m1': 3, 'm2': 7}, 'B': {'m1': 7, 'm2': 3}})
+    category_capacities = {'c1': 1}
+
+    # Invalid: tuple of items instead of list
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ('m1', 'm2')}, category_capacities, ['A', 'B'])
+    # Invalid: set of items instead of list
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': {'m1', 'm2'}}, category_capacities, ['A', 'B'])
+
+
+def test_validate_check5_at_least_one_agent():
+    """Check 5: the instance must have at least one agent — empty instance raises ValueError."""
+    # Invalid: instance with no agents at all
+    empty_alloc = AllocationBuilder(Instance(valuations={}))
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(empty_alloc, {'c1': ['g1']}, {'c1': 1}, None)
+
+    # Invalid: initial_agent_order=[] while the instance has agents
+    alloc = _make_alloc({'Alice': {'g1': 5, 'g2': 3}, 'Bob': {'g1': 3, 'g2': 5}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['g1', 'g2']}, {'c1': 1}, [])
+
+
+def test_validate_check6_at_least_one_category():
+    """Check 6: item_categories must not be empty — no categories at all raises ValueError."""
+    alloc = _make_alloc({'A': {'g1': 5}, 'B': {'g1': 3}})
+
+    # Invalid: empty dict means no categories exist
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {}, {}, ['A', 'B'])
+
+
+def test_validate_check7_no_empty_category():
+    """Check 7: every category must contain at least one item — empty list raises ValueError."""
+    alloc = _make_alloc({'A': {'m1': 5, 'm2': 3}, 'B': {'m1': 3, 'm2': 7}})
+
+    # Invalid: the only category has an empty item list
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': []}, {'c1': 1}, ['A', 'B'])
+    # Invalid: one of two categories is empty
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1', 'm2'], 'c2': []},
+            {'c1': 1, 'c2': 1},
+            ['A', 'B'],
+        )
+
+
+def test_validate_check8_agent_order_is_valid_permutation():
+    """Check 8: if given, initial_agent_order must be an exact permutation of all agents."""
     alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    item_categories = {'c1': ['m1', 'm2']}
+    category_capacities = {'c1': 1}
+
+    # Valid: None skips this check entirely
+    validate_fair_division_inputs(alloc, item_categories, category_capacities, None)  # must not raise
+    # Valid: correct permutation
+    validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Bob', 'Alice'])  # must not raise
+
+    # Invalid: one agent missing from the order
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice'])
+    # Invalid: duplicate agent (Bob appears twice, Alice missing)
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Alice'])
+    # Invalid: unknown agent 'Charlie' not in instance
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Charlie'])
+    # Invalid: correct agents plus an extra unknown agent
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, category_capacities, ['Alice', 'Bob', 'Eve'])
+
+
+def test_validate_check9_capacities_keys_match_categories():
+    """Check 9: category_capacities keys must match item_categories keys exactly."""
+    alloc = _make_alloc({'A': {'g1': 5, 'g2': 3, 'g3': 7}, 'B': {'g1': 7, 'g2': 5, 'g3': 3}})
+
+    # Valid: keys match exactly
     validate_fair_division_inputs(
         alloc,
-        item_categories={'c1': ['m1', 'm2']},
-        category_capacities={'c1': 1},
-        initial_agent_order=['Alice', 'Bob'],
+        {'c1': ['g1', 'g2'], 'c2': ['g3']},
+        {'c1': 1, 'c2': 1},
+        ['A', 'B'],
     )  # must not raise
 
-
-def test_validate_boundary_k_h():
-    """k_h == ceil(|C_h| / n) is the minimum valid threshold — must not raise."""
-    # 3 goods, 2 agents → k_h >= ceil(3/2) = 2
-    alloc = _make_alloc({
-        'Alice': {'m1': 5, 'm2': 3, 'm3': 1},
-        'Bob':   {'m1': 1, 'm2': 3, 'm3': 5},
-    })
-    validate_fair_division_inputs(
-        alloc,
-        item_categories={'c1': ['m1', 'm2', 'm3']},
-        category_capacities={'c1': 2},  # exactly ceil(3/2)
-        initial_agent_order=['Alice', 'Bob'],
-    )  # must not raise
-
-
-def test_validate_empty_order():
-    """Empty initial_agent_order while instance has agents → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5}, 'Bob': {'m1': 3}})
+    # Invalid: c2 exists in item_categories but has no threshold
     with pytest.raises(ValueError):
-        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, [])
-
-
-def test_validate_duplicate_in_order():
-    """Duplicate agent in initial_agent_order → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5}, 'Bob': {'m1': 3}})
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['g1', 'g2'], 'c2': ['g3']},
+            {'c1': 1},
+            ['A', 'B'],
+        )
+    # Invalid: c99 appears in category_capacities but not in item_categories
     with pytest.raises(ValueError):
-        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, ['Alice', 'Alice'])
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['g1', 'g2', 'g3']},
+            {'c1': 1, 'c99': 2},
+            ['A', 'B'],
+        )
 
 
-def test_validate_item_in_two_categories():
-    """Same item listed in two categories → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+def test_validate_check10_items_in_categories_exist_in_instance():
+    """Check 10: every item listed in item_categories must exist in the instance valuations."""
+    alloc = _make_alloc({'A': {'g1': 5, 'g2': 3}, 'B': {'g1': 3, 'g2': 7}})
+
+    # Invalid: 'ghost' is listed in a category but has no valuation in the instance
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['g1', 'ghost']}, {'c1': 1}, ['A', 'B'])
+    # Invalid: entirely unknown item
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['g1'], 'c2': ['g2', 'g99']}, {'c1': 1, 'c2': 1}, ['A', 'B'])
+
+
+def test_validate_check11_all_instance_items_are_categorised():
+    """Check 11: every item in the instance valuations must appear in at least one category."""
+    alloc = _make_alloc({'A': {'g1': 5, 'g2': 3, 'g3': 8}, 'B': {'g1': 3, 'g2': 7, 'g3': 2}})
+
+    # Invalid: g3 is in the instance but not listed in any category
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['g1', 'g2']},
+            {'c1': 1},
+            ['A', 'B'],
+        )
+    # Invalid: g2 and g3 both uncategorised
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['g1']}, {'c1': 1}, ['A', 'B'])
+
+
+def test_validate_check12_no_item_in_two_categories():
+    """Check 12: no item may appear in more than one category."""
+    alloc = _make_alloc({'A': {'m1': 5, 'm2': 3}, 'B': {'m1': 3, 'm2': 7}})
+
+    # Invalid: m1 appears in both c1 and c2
     with pytest.raises(ValueError):
         validate_fair_division_inputs(
             alloc,
             {'c1': ['m1', 'm2'], 'c2': ['m1']},
             {'c1': 1, 'c2': 1},
-            ['Alice', 'Bob'],
+            ['A', 'B'],
         )
-
-
-def test_validate_item_missing_from_categories():
-    """Item in valuations but absent from all categories → ValueError."""
-    # alloc has m1 and m2 in instance, but categories only cover m1
-    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
-    with pytest.raises(ValueError):
-        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, ['Alice', 'Bob'])
-
-
-def test_validate_missing_threshold():
-    """Category in item_categories has no entry in category_capacities → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    # Invalid: m2 duplicated across two categories
     with pytest.raises(ValueError):
         validate_fair_division_inputs(
             alloc,
-            {'c1': ['m1'], 'c2': ['m2']},
-            {'c1': 1},           # missing 'c2'
-            ['Alice', 'Bob'],
+            {'c1': ['m1', 'm2'], 'c2': ['m2']},
+            {'c1': 1, 'c2': 1},
+            ['A', 'B'],
         )
 
 
-def test_validate_extra_threshold():
-    """Key in category_capacities with no matching category in item_categories → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+def test_validate_check13_non_negative_valuations():
+    """Check 13: all valuation values must be >= 0 — negative values raise ValueError."""
+    # Valid: zero valuation is allowed
+    alloc_zero = _make_alloc({'A': {'g1': 0, 'g2': 5}, 'B': {'g1': 5, 'g2': 0}})
+    validate_fair_division_inputs(alloc_zero, {'c1': ['g1', 'g2']}, {'c1': 1}, ['A', 'B'])  # must not raise
+
+    # Invalid: one agent has a negative value for a good
+    alloc_neg = _make_alloc({'A': {'g1': -1, 'g2': 5}, 'B': {'g1': 5, 'g2': 3}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc_neg, {'c1': ['g1', 'g2']}, {'c1': 1}, ['A', 'B'])
+    # Invalid: negative value hidden in a multi-category instance
+    alloc_neg2 = _make_alloc({'A': {'g1': 3, 'g2': -2, 'g3': 5}, 'B': {'g1': 5, 'g2': 4, 'g3': -1}})
     with pytest.raises(ValueError):
         validate_fair_division_inputs(
-            alloc,
-            {'c1': ['m1', 'm2']},
-            {'c1': 1, 'c99': 2},  # 'c99' not in item_categories
-            ['Alice', 'Bob'],
+            alloc_neg2,
+            {'c1': ['g1', 'g2'], 'c2': ['g3']},
+            {'c1': 1, 'c2': 1},
+            ['A', 'B'],
         )
 
 
-def test_validate_k_h_zero():
-    """k_h = 0 is not a positive integer → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+def test_validate_check14_k_h_is_positive_integer():
+    """Check 14: each k_h must be a positive integer — zero, negative, or non-integer raises ValueError."""
+    alloc = _make_alloc({'A': {'g1': 5, 'g2': 3}, 'B': {'g1': 3, 'g2': 7}})
+    item_categories = {'c1': ['g1', 'g2']}
+
+    # Invalid: zero is not positive
     with pytest.raises(ValueError):
-        validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2']}, {'c1': 0}, ['Alice', 'Bob'])
+        validate_fair_division_inputs(alloc, item_categories, {'c1': 0}, ['A', 'B'])
+    # Invalid: negative integer
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, {'c1': -1}, ['A', 'B'])
+    # Invalid: float, even if it looks like a whole number
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, {'c1': 1.5}, ['A', 'B'])
+    # Invalid: string representation of a number
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, item_categories, {'c1': '1'}, ['A', 'B'])
 
 
-def test_validate_k_h_too_small():
-    """k_h < ceil(|C_h| / n) violates the feasibility condition → ValueError."""
-    # 3 goods, 2 agents → k_h must be >= ceil(3/2) = 2; k_h=1 is too small
+def test_validate_check15_k_h_feasibility():
+    """Check 15: k_h >= ceil(|C_h| / n) — ensures all goods in the category can be distributed."""
+    # 3 goods, 2 agents → minimum k_h = ceil(3/2) = 2
     alloc = _make_alloc({
-        'Alice': {'m1': 5, 'm2': 3, 'm3': 1},
-        'Bob':   {'m1': 1, 'm2': 3, 'm3': 5},
+        'A': {'g1': 9, 'g2': 5, 'g3': 1},
+        'B': {'g1': 1, 'g2': 5, 'g3': 9},
     })
-    with pytest.raises(ValueError):
-        validate_fair_division_inputs(
-            alloc,
-            {'c1': ['m1', 'm2', 'm3']},
-            {'c1': 1},
-            ['Alice', 'Bob'],
-        )
 
+    # Valid: k_h=2 is exactly the minimum (boundary case)
+    validate_fair_division_inputs(alloc, {'c1': ['g1', 'g2', 'g3']}, {'c1': 2}, ['A', 'B'])  # must not raise
+    # Valid: k_h=3 is above the minimum
+    validate_fair_division_inputs(alloc, {'c1': ['g1', 'g2', 'g3']}, {'c1': 3}, ['A', 'B'])  # must not raise
 
-def test_validate_negative_valuation():
-    """Negative valuation value → ValueError."""
-    alloc = _make_alloc({'Alice': {'m1': -1, 'm2': 3}, 'Bob': {'m1': 4, 'm2': 6}})
+    # Invalid: k_h=1 → only 2*1=2 goods can be allocated but there are 3
     with pytest.raises(ValueError):
-        validate_fair_division_inputs(
-            alloc,
-            {'c1': ['m1', 'm2']},
-            {'c1': 1},
-            ['Alice', 'Bob'],
-        )
+        validate_fair_division_inputs(alloc, {'c1': ['g1', 'g2', 'g3']}, {'c1': 1}, ['A', 'B'])
+
+    # Multi-category case: c1 has 4 goods, 3 agents → k_h >= ceil(4/3) = 2
+    alloc2 = _make_alloc({
+        'X': {'g1': 9, 'g2': 7, 'g3': 4, 'g4': 1},
+        'Y': {'g1': 1, 'g2': 4, 'g3': 7, 'g4': 9},
+        'Z': {'g1': 5, 'g2': 5, 'g3': 5, 'g4': 5},
+    })
+    # Valid: k_h=2 == ceil(4/3)
+    validate_fair_division_inputs(alloc2, {'c1': ['g1', 'g2', 'g3', 'g4']}, {'c1': 2}, ['X', 'Y', 'Z'])  # must not raise
+    # Invalid: k_h=1 → only 3*1=3 goods can be allocated but there are 4
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc2, {'c1': ['g1', 'g2', 'g3', 'g4']}, {'c1': 1}, ['X', 'Y', 'Z'])
 
 
 # ---------------------------------------------------------------------------
@@ -823,6 +821,10 @@ def test_validate_negative_valuation():
 
 def test_random_integration_small():
     """3-5 agents, 10-20 goods, 2-4 categories: EF1 and cardinality must hold."""
+    # Each tuple is (num_agents, num_items, num_categories, seed).
+    # The range of sizes covers the most common real-world scenarios:
+    # few agents, moderate number of goods, 2-4 categories.
+    # Fixed seeds make failures fully reproducible.
     configs = [
         (3, 12, 2, 101),
         (4, 16, 3, 202),
@@ -831,6 +833,7 @@ def test_random_integration_small():
         (4, 15, 3, 505),
     ]
     for num_agents, num_items, num_categories, seed in configs:
+        # Generate a fresh valid random instance for this configuration.
         valuations, item_categories, category_capacities, agent_order = random_valid_instance(
             num_agents, num_items, num_categories, seed
         )
@@ -842,9 +845,12 @@ def test_random_integration_small():
             category_capacities=category_capacities,
             initial_agent_order=agent_order,
         )
+        # Guarantee 1: no agent receives more than k_h goods from any single category.
         assert check_cardinality_constraints(result, item_categories, category_capacities), (
             f"Config ({num_agents},{num_items},{num_categories},seed={seed}): cardinality violated"
         )
+        # Guarantee 2: EF1 holds — for every pair (i,j), removing j's most valued good
+        # by i eliminates i's envy (Biswas & Barman 2018, Theorem 1).
         assert check_ef1(result, valuations), (
             f"Config ({num_agents},{num_items},{num_categories},seed={seed}): EF1 violated"
         )
@@ -852,12 +858,16 @@ def test_random_integration_small():
 
 def test_random_integration_large():
     """6-8 agents, 30-50 goods, 4-6 categories: EF1 and cardinality must hold."""
+    # Larger instances stress-test the algorithm's correctness at scale.
+    # More agents and categories means more envy cycles and more topo-sort reorderings,
+    # so bugs that only surface in complex interactions are more likely to appear here.
     configs = [
         (6, 30, 4, 1001),
         (7, 35, 5, 2002),
         (8, 50, 6, 3003),
     ]
     for num_agents, num_items, num_categories, seed in configs:
+        # Generate a fresh valid random instance for this configuration.
         valuations, item_categories, category_capacities, agent_order = random_valid_instance(
             num_agents, num_items, num_categories, seed
         )
@@ -869,9 +879,12 @@ def test_random_integration_large():
             category_capacities=category_capacities,
             initial_agent_order=agent_order,
         )
+        # Guarantee 1: no agent receives more than k_h goods from any single category.
         assert check_cardinality_constraints(result, item_categories, category_capacities), (
             f"Config ({num_agents},{num_items},{num_categories},seed={seed}): cardinality violated"
         )
+        # Guarantee 2: EF1 holds — for every pair (i,j), removing j's most valued good
+        # by i eliminates i's envy (Biswas & Barman 2018, Theorem 1).
         assert check_ef1(result, valuations), (
             f"Config ({num_agents},{num_items},{num_categories},seed={seed}): EF1 violated"
         )

--- a/tests/test_fair_division_under_cardinality_constraints.py
+++ b/tests/test_fair_division_under_cardinality_constraints.py
@@ -193,49 +193,6 @@ def test_algorithm1_all_goods_allocated():
         )
 
 
-def test_algorithm1_cardinality_constraints():
-    """No agent receives more than k_h goods from any category."""
-    for i in range(NUM_OF_RANDOM_INSTANCES):
-        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
-            num_agents=4, num_items=20, num_categories=3, seed=i * 13
-        )
-        instance = Instance(valuations=valuations)
-        result = divide(
-            algorithm=fair_division_under_cardinality_constraints,
-            instance=instance,
-            item_categories=item_categories,
-            category_capacities=category_capacities,
-            initial_agent_order=agent_order,
-        )
-        # check_cardinality_constraints verifies that for every agent and every category h,
-        # the number of goods from h in the agent's bundle does not exceed k_h.
-        assert check_cardinality_constraints(result, item_categories, category_capacities), (
-            f"Seed {i * 13}: cardinality constraint violated. result={result}"
-        )
-
-
-def test_algorithm1_ef1():
-    """The algorithm guarantees EF1 (Biswas & Barman 2018, Theorem 1)."""
-    for i in range(NUM_OF_RANDOM_INSTANCES):
-        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
-            num_agents=4, num_items=20, num_categories=3, seed=i * 17
-        )
-        instance = Instance(valuations=valuations)
-        result = divide(
-            algorithm=fair_division_under_cardinality_constraints,
-            instance=instance,
-            item_categories=item_categories,
-            category_capacities=category_capacities,
-            initial_agent_order=agent_order,
-        )
-        # check_ef1 verifies that for every pair (i, j), removing the good i values most
-        # from j's bundle eliminates i's envy — the EF1 guarantee from the paper.
-        # We include the valuations dict so check_ef1 can look up values by agent and good name.
-        assert check_ef1(result, valuations), (
-            f"Seed {i * 17}: EF1 violated. valuations={valuations}, result={result}"
-        )
-
-
 def test_algorithm1_default_order():
     """Passing initial_agent_order=None defaults to sorted(agents), giving the same result."""
     valuations = {
@@ -246,6 +203,7 @@ def test_algorithm1_default_order():
     item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
     category_capacities = {'c1': 1, 'c2': 1}
 
+    # Run once with None — the algorithm should default to sorted(agents) internally.
     result_none = divide(
         algorithm=fair_division_under_cardinality_constraints,
         instance=instance,
@@ -253,6 +211,7 @@ def test_algorithm1_default_order():
         category_capacities=category_capacities,
         initial_agent_order=None,
     )
+    # Run again with the sorted order passed explicitly.
     result_sorted = divide(
         algorithm=fair_division_under_cardinality_constraints,
         instance=instance,
@@ -260,6 +219,11 @@ def test_algorithm1_default_order():
         category_capacities=category_capacities,
         initial_agent_order=sorted(valuations.keys()),
     )
+
+    # Sanity check: the allocation must be non-trivial (goods were actually distributed).
+    assert any(result_none[a] for a in result_none), "allocation is empty — algorithm did not run"
+
+    # Core check: both calls must produce identical results, proving None == sorted order.
     assert result_none == result_sorted
 
 
@@ -415,6 +379,8 @@ def test_eliminate_no_cycle():
     #   Bob   values own bundle=9, Alice's bundle=3 → Bob   does NOT envy Alice.
     # No edges → graph is already a DAG. No cycle to eliminate.
     G = eliminate_envy_cycles(alloc)
+    # Graph must contain a node for every agent.
+    assert set(G.nodes()) == {'Alice', 'Bob'}
     assert list(nz.simple_cycles(G)) == []
     # Bundles must be untouched — no rotation happened.
     assert sorted(alloc.bundles['Alice']) == ['m1']
@@ -487,6 +453,7 @@ def test_eliminate_result_is_dag():
         # The paper guarantees eliminate_envy_cycles always produces a DAG.
         # We verify this holds for every random allocation.
         G = eliminate_envy_cycles(alloc)
+        assert set(G.nodes()) == set(agents), f"Seed {i * 3}: graph missing agent nodes"
         assert list(nz.simple_cycles(G)) == [], f"Seed {i * 3}: cycle found in result graph"
 
 
@@ -510,7 +477,8 @@ def test_eliminate_no_value_decrease():
             a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
             for a in agents
         }
-        eliminate_envy_cycles(alloc)
+        G = eliminate_envy_cycles(alloc)
+        assert set(G.nodes()) == set(agents), f"Seed {i * 11}: graph missing agent nodes"
         # Snapshot each agent's total value after cycle elimination.
         value_after = {
             a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
@@ -601,13 +569,8 @@ def test_validate_check4_category_values_are_lists():
 
 
 def test_validate_check5_at_least_one_agent():
-    """Check 5: the instance must have at least one agent — empty instance raises ValueError."""
-    # Invalid: instance with no agents at all
-    empty_alloc = AllocationBuilder(Instance(valuations={}))
-    with pytest.raises(ValueError):
-        validate_fair_division_inputs(empty_alloc, {'c1': ['g1']}, {'c1': 1}, None)
-
-    # Invalid: initial_agent_order=[] while the instance has agents
+    """Check 5: initial_agent_order must not be empty — empty list raises ValueError.
+    Empty valuations are rejected by the fairpyx framework before reaching this function."""
     alloc = _make_alloc({'Alice': {'g1': 5, 'g2': 3}, 'Bob': {'g1': 3, 'g2': 5}})
     with pytest.raises(ValueError):
         validate_fair_division_inputs(alloc, {'c1': ['g1', 'g2']}, {'c1': 1}, [])
@@ -845,6 +808,12 @@ def test_random_integration_small():
             category_capacities=category_capacities,
             initial_agent_order=agent_order,
         )
+        # Sanity: every good must appear in exactly one bundle.
+        all_goods = sorted(g for items in item_categories.values() for g in items)
+        allocated = sorted(g for bundle in result.values() for g in bundle)
+        assert allocated == all_goods, (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): not all goods allocated"
+        )
         # Guarantee 1: no agent receives more than k_h goods from any single category.
         assert check_cardinality_constraints(result, item_categories, category_capacities), (
             f"Config ({num_agents},{num_items},{num_categories},seed={seed}): cardinality violated"
@@ -878,6 +847,12 @@ def test_random_integration_large():
             item_categories=item_categories,
             category_capacities=category_capacities,
             initial_agent_order=agent_order,
+        )
+        # Sanity: every good must appear in exactly one bundle.
+        all_goods = sorted(g for items in item_categories.values() for g in items)
+        allocated = sorted(g for bundle in result.values() for g in bundle)
+        assert allocated == all_goods, (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): not all goods allocated"
         )
         # Guarantee 1: no agent receives more than k_h goods from any single category.
         assert check_cardinality_constraints(result, item_categories, category_capacities), (

--- a/tests/test_fair_division_under_cardinality_constraints.py
+++ b/tests/test_fair_division_under_cardinality_constraints.py
@@ -1,0 +1,881 @@
+"""
+Test the Fair Division Under Cardinality Constraints algorithm.
+
+Programmer: Sapir Dahan
+Since:  2026-04
+"""
+
+import math
+import pytest
+import numpy as np
+import networkz as nz
+from fairpyx import Instance, AllocationBuilder, divide
+from fairpyx.algorithms.fair_division_under_cardinality_constraints import (
+    fair_division_under_cardinality_constraints,
+    greedy_round_robin,
+    eliminate_envy_cycles,
+    validate_fair_division_inputs,
+)
+
+NUM_OF_RANDOM_INSTANCES = 10
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def check_ef1(result, valuations):
+    """
+    Return True iff the allocation satisfies EF1 (Envy-Free up to one good).
+
+    EF1 definition: for every pair of agents (i, j), there EXISTS some good g in j's
+    bundle such that when g is removed, i no longer envies j:
+        v_i(result[i]) >= v_i(result[j] \\ {g})
+
+    To check whether such a g exists, we look at the good in j's bundle that i values
+    MOST. Removing the highest-valued item causes the largest drop in v_i(result[j]),
+    giving us the best possible chance of eliminating the envy. If even removing that
+    item is not enough, then no single removal can fix the envy and EF1 fails.
+
+    Formally: EF1 holds for pair (i, j) iff
+        v_i(result[i]) >= v_i(result[j]) - max_{g in result[j]} v_i(g)
+    """
+    agents = list(result.keys())
+    for i in agents:
+        # How much agent i values their own bundle
+        val_i_own = sum(valuations[i].get(g, 0) for g in result[i])
+        for j in agents:
+            if i == j:
+                continue
+            # How much agent i values j's bundle
+            val_i_other = sum(valuations[i].get(g, 0) for g in result[j])
+            if val_i_other <= val_i_own:
+                continue  # i does not envy j at all — EF1 trivially holds for this pair
+
+            # i envies j, check EF1: can removing one good from j's bundle fix it?
+            if not result[j]:
+                # j has an empty bundle but i envies them — logically impossible, skip
+                continue
+
+            # The best single removal: take away the item i values most in j's bundle.
+            # If val_i_own >= val_i_other - max_val, envy disappears → EF1 holds for (i, j).
+            # If not, no single removal helps → EF1 is violated.
+            max_val = max(valuations[i].get(g, 0) for g in result[j])
+            if val_i_own < val_i_other - max_val:
+                return False  # EF1 violated: even removing j's best item is not enough
+
+    return True
+
+
+def check_cardinality_constraints(result, item_categories, category_capacities):
+    """
+    Return True iff every agent's bundle respects the per-category threshold k_h.
+
+    For each agent and each category h, count how many goods from that category the
+    agent received. This count must not exceed k_h (the shared capacity for category h).
+    """
+    for agent, bundle in result.items():
+        for category, items in item_categories.items():
+            # Count how many goods from this category the agent received
+            count = sum(1 for g in bundle if g in items)
+            # k_h is the maximum allowed goods per agent from this category
+            if count > category_capacities[category]:
+                return False  # agent received too many goods from this category
+    return True
+
+
+def random_valid_instance(num_agents, num_items, num_categories, seed):
+    """
+    Generate a valid random instance for fair_division_under_cardinality_constraints.
+    Returns (valuations, item_categories, category_capacities, agent_order).
+
+    All generated instances satisfy the algorithm's preconditions:
+      - goods are partitioned into exactly num_categories non-empty categories
+      - each threshold k_h >= ceil(|C_h| / n)  (feasibility condition from the paper)
+      - all valuations are non-negative integers
+    """
+    rng = np.random.default_rng(seed)
+
+    # Build agent and good name lists.
+    # Example: num_agents=3, num_items=6 → agents=['a1','a2','a3'], goods=['g1',...,'g6']
+    agents = [f"a{i}" for i in range(1, num_agents + 1)]
+    goods = [f"g{i}" for i in range(1, num_items + 1)]
+
+    # --- Partition goods into num_categories non-empty categories ---
+    # We want each category to contain a random subset of goods, not just a prefix.
+    # Strategy: shuffle the goods list first, then cut it at (num_categories-1) random
+    # positions to produce num_categories non-empty slices.
+    #
+    # Example with 6 goods and 3 categories:
+    #   shuffled  = ['g4', 'g1', 'g6', 'g2', 'g5', 'g3']
+    #   cut points chosen from {1,2,3,4,5}: say [2, 4]
+    #   → full cut_points = [0, 2, 4, 6]
+    #   → c1 = shuffled[0:2] = ['g4','g1']
+    #     c2 = shuffled[2:4] = ['g6','g2']
+    #     c3 = shuffled[4:6] = ['g5','g3']
+    shuffled = list(goods)
+    rng.shuffle(shuffled)
+
+    # replace=False guarantees all cut points are distinct integers from {1,...,num_items-1},
+    # so after sorting: each consecutive pair differs by >= 1 → every slice is non-empty.
+    cut_points = sorted(rng.choice(range(1, num_items), num_categories - 1, replace=False).tolist())
+    cut_points = [0] + cut_points + [num_items]
+    item_categories = {
+        f"c{h + 1}": shuffled[cut_points[h]:cut_points[h + 1]]
+        for h in range(num_categories)
+    }
+
+    # --- Set thresholds: k_h >= ceil(|C_h| / n) ---
+    # The paper requires n * k_h >= |C_h| so that all goods in category h can be
+    # distributed (n agents, each taking at most k_h goods from h).
+    # Rearranged: k_h >= ceil(|C_h| / n).
+    #
+    # Example: |C_h| = 5 goods, n = 3 agents → k_h >= ceil(5/3) = 2.
+    #   With k_h=2 every agent takes at most 2 goods from c_h; 3*2=6 >= 5, so all goods fit.
+    #   With k_h=1 only 3*1=3 goods could be allocated, leaving 2 goods unallocated — invalid.
+    #
+    # We add a small random slack of 0 or 1 so we also test non-tight (loose) thresholds.
+    category_capacities = {
+        cat: int(math.ceil(len(items) / num_agents)) + int(rng.integers(0, 2))
+        for cat, items in item_categories.items()
+    }
+
+    # --- Generate non-negative integer valuations ---
+    # Each agent independently assigns a random value in [0, 19] to every good.
+    # Valuations are additive: an agent's value for a bundle is the sum over its goods.
+    #
+    # Example with 2 agents and 3 goods:
+    #   valuations = {
+    #       'a1': {'g1': 12, 'g2': 0, 'g3': 7},
+    #       'a2': {'g1': 3,  'g2': 15, 'g3': 9},
+    #   }
+    valuations = {
+        a: {g: int(rng.integers(0, 20)) for g in goods}
+        for a in agents
+    }
+
+    # --- Shuffle agent order to avoid bias toward any fixed picking sequence ---
+    # The initial_agent_order determines who picks first in the first category.
+    # Shuffling here ensures tests cover many different starting orders, not always a1 first.
+    agent_order = list(agents)
+    rng.shuffle(agent_order)
+
+    return valuations, item_categories, category_capacities, agent_order
+
+
+# ---------------------------------------------------------------------------
+# Section 1: fair_division_under_cardinality_constraints (Algorithm 1)
+# ---------------------------------------------------------------------------
+
+def test_algorithm1_doctest_instances():
+    """Replicate the doctest examples 1-10 with exact expected outputs."""
+
+    # Example 1: basic — 2 agents, 2 categories, k_h=1
+    valuations = {
+        'Agent1': {'m1': 9, 'm2': 3, 'm3': 8, 'm4': 2},
+        'Agent2': {'m1': 3, 'm2': 9, 'm3': 2, 'm4': 8},
+    }
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations),
+        item_categories={'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']},
+        category_capacities={'c1': 1, 'c2': 1},
+        initial_agent_order=['Agent1', 'Agent2'],
+    )
+    assert result == {'Agent1': ['m1', 'm3'], 'Agent2': ['m2', 'm4']}
+
+    # Example 2: 3 agents, 2 categories of 3 goods each, k_h=1
+    valuations = {
+        'Agent1': {'m1': 9, 'm2': 6, 'm3': 3, 'm4': 8, 'm5': 5, 'm6': 2},
+        'Agent2': {'m1': 3, 'm2': 9, 'm3': 6, 'm4': 2, 'm5': 8, 'm6': 5},
+        'Agent3': {'m1': 6, 'm2': 3, 'm3': 9, 'm4': 5, 'm5': 2, 'm6': 8},
+    }
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations),
+        item_categories={'c1': ['m1', 'm2', 'm3'], 'c2': ['m4', 'm5', 'm6']},
+        category_capacities={'c1': 1, 'c2': 1},
+        initial_agent_order=['Agent1', 'Agent2', 'Agent3'],
+    )
+    assert result == {'Agent1': ['m1', 'm4'], 'Agent2': ['m2', 'm5'], 'Agent3': ['m3', 'm6']}
+
+    # Example 3: single agent — trivially receives all goods
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations={'Alice': {'m1': 10, 'm2': 7, 'm3': 4}}),
+        item_categories={'c1': ['m1', 'm2', 'm3']},
+        category_capacities={'c1': 3},
+        initial_agent_order=['Alice'],
+    )
+    assert result == {'Alice': ['m1', 'm2', 'm3']}
+
+    # Example 4: single category — greedy_round_robin only, k_h=2
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations={'A': {'x': 10, 'y': 5, 'z': 1}, 'B': {'x': 1, 'y': 5, 'z': 10}}),
+        item_categories={'c1': ['x', 'y', 'z']},
+        category_capacities={'c1': 2},
+        initial_agent_order=['A', 'B'],
+    )
+    assert result == {'A': ['x', 'y'], 'B': ['z']}
+
+    # Example 5: single good per category — envy after c1 reverses order for c2
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations={'Agent1': {'m1': 8, 'm2': 5}, 'Agent2': {'m1': 5, 'm2': 8}}),
+        item_categories={'c1': ['m1'], 'c2': ['m2']},
+        category_capacities={'c1': 1, 'c2': 1},
+        initial_agent_order=['Agent1', 'Agent2'],
+    )
+    assert result == {'Agent1': ['m1'], 'Agent2': ['m2']}
+
+    # Example 6: asymmetric category sizes
+    valuations = {
+        'Agent1': {'m1': 10, 'm2': 8, 'm3': 6, 'm4': 4, 'm5': 9},
+        'Agent2': {'m1': 4,  'm2': 6, 'm3': 8, 'm4': 10, 'm5': 7},
+    }
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations),
+        item_categories={'c1': ['m1', 'm2', 'm3', 'm4'], 'c2': ['m5']},
+        category_capacities={'c1': 2, 'c2': 1},
+        initial_agent_order=['Agent1', 'Agent2'],
+    )
+    assert result == {'Agent1': ['m1', 'm2', 'm5'], 'Agent2': ['m3', 'm4']}
+
+    # Example 7: minimal base case — 1 agent, 1 good
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations={'a1': {'g1': 2}}),
+        item_categories={'C1': ['g1']},
+        category_capacities={'C1': 1},
+        initial_agent_order=['a1'],
+    )
+    assert result == {'a1': ['g1']}
+
+    # Example 8: 2 agents, 2 goods, 1 category, k_h=1
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations={'a1': {'g1': 2, 'g2': 3}, 'a2': {'g1': 1, 'g2': 4}}),
+        item_categories={'C1': ['g1', 'g2']},
+        category_capacities={'C1': 1},
+        initial_agent_order=['a1', 'a2'],
+    )
+    assert result == {'a1': ['g2'], 'a2': ['g1']}
+
+    # Example 9: 2 agents, 6 goods, 2 categories, k_h=2 — order reverses for C2
+    valuations = {
+        'a1': {'g1': 9, 'g2': 6, 'g3': 3, 'g4': 8, 'g5': 5, 'g6': 2},
+        'a2': {'g1': 4, 'g2': 7, 'g3': 8, 'g4': 3, 'g5': 9, 'g6': 6},
+    }
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations),
+        item_categories={'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']},
+        category_capacities={'C1': 2, 'C2': 2},
+        initial_agent_order=['a1', 'a2'],
+    )
+    assert result == {'a1': ['g1', 'g2', 'g4'], 'a2': ['g3', 'g5', 'g6']}
+
+    # Example 10: 3 agents, 6 goods, 2 categories — multiple overlapping cycles
+    valuations = {
+        'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
+        'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
+        'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
+    }
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations),
+        item_categories={'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']},
+        category_capacities={'C1': 1, 'C2': 1},
+        initial_agent_order=['a1', 'a2', 'a3'],
+    )
+    assert result == {'a1': ['g2', 'g5'], 'a2': ['g3', 'g4'], 'a3': ['g1', 'g6']}
+
+    # Example 11: 4 agents, 26 goods, 4 categories, k_h=2 (large instance from the paper)
+    # The topological sort uses lex secondary sort (by agent name), making the output fully
+    # deterministic. Once the implementation runs, replace the property checks below with
+    # an exact assertion (assert result11 == {...}).
+    # For now we verify the three core guarantees:
+    valuations_11 = {
+        'a1': {'g1':9,'g2':4,'g3':8,'g4':1,'g5':6,'g6':2,'g7':10,'g8':3,'g9':5,'g10':1,'g11':7,
+               'g12':6,'g13':2,'g14':9,'g15':4,'g16':8,'g17':1,'g18':3,
+               'g19':5,'g20':7,'g21':2,'g22':10,'g23':4,'g24':6,'g25':1,'g26':8},
+        'a2': {'g1':3,'g2':10,'g3':2,'g4':7,'g5':5,'g6':9,'g7':1,'g8':8,'g9':4,'g10':6,'g11':2,
+               'g12':1,'g13':7,'g14':3,'g15':10,'g16':5,'g17':8,'g18':4,
+               'g19':6,'g20':2,'g21':9,'g22':1,'g23':7,'g24':3,'g25':10,'g26':5},
+        'a3': {'g1':8,'g2':1,'g3':5,'g4':9,'g5':2,'g6':4,'g7':6,'g8':10,'g9':1,'g10':7,'g11':3,
+               'g12':9,'g13':5,'g14':2,'g15':6,'g16':1,'g17':10,'g18':4,
+               'g19':8,'g20':3,'g21':6,'g22':2,'g23':9,'g24':1,'g25':5,'g26':7},
+        'a4': {'g1':2,'g2':6,'g3':10,'g4':3,'g5':7,'g6':5,'g7':2,'g8':1,'g9':10,'g10':8,'g11':4,
+               'g12':3,'g13':9,'g14':6,'g15':2,'g16':7,'g17':5,'g18':10,
+               'g19':1,'g20':8,'g21':4,'g22':6,'g23':2,'g24':10,'g25':3,'g26':9},
+    }
+    item_categories_11 = {
+        'C1': ['g1','g2','g3','g4','g5'],
+        'C2': ['g6','g7','g8','g9','g10','g11'],
+        'C3': ['g12','g13','g14','g15','g16','g17','g18'],
+        'C4': ['g19','g20','g21','g22','g23','g24','g25','g26'],
+    }
+    category_capacities_11 = {'C1': 2, 'C2': 2, 'C3': 2, 'C4': 2}
+    all_goods_11 = [f'g{i}' for i in range(1, 27)]
+    result11 = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=Instance(valuations=valuations_11),
+        item_categories=item_categories_11,
+        category_capacities=category_capacities_11,
+        initial_agent_order=['a1', 'a2', 'a3', 'a4'],
+    )
+    assert sorted(g for bundle in result11.values() for g in bundle) == sorted(all_goods_11), \
+        "Example 11: not all 26 goods were allocated"
+    assert check_cardinality_constraints(result11, item_categories_11, category_capacities_11), \
+        f"Example 11: cardinality constraint violated. result={result11}"
+    assert check_ef1(result11, valuations_11), \
+        f"Example 11: EF1 violated. result={result11}"
+    # Exact output — hand-traced (no value ties anywhere, fully deterministic):
+    # C1 σ=['a1','a2','a3','a4']: a1←g1,g5  a2←g2  a3←g4  a4←g3
+    # Envy after C1: a3→a1 only. Topo sort → ['a2','a3','a4','a1']
+    # C2 σ=['a2','a3','a4','a1']: a2←g6,g10  a3←g8,g11  a4←g9  a1←g7
+    # No envy after C2. Topo sort → ['a1','a2','a3','a4']
+    # C3 σ=['a1','a2','a3','a4']: a1←g14,g16  a2←g15,g13  a3←g17,g12  a4←g18
+    # No envy after C3. Topo sort → ['a1','a2','a3','a4']
+    # C4 σ=['a1','a2','a3','a4']: a1←g22,g26  a2←g25,g21  a3←g23,g19  a4←g24,g20
+    assert result11 == {
+        'a1': ['g1', 'g14', 'g16', 'g22', 'g26', 'g5', 'g7'],
+        'a2': ['g10', 'g13', 'g15', 'g2', 'g21', 'g25', 'g6'],
+        'a3': ['g11', 'g12', 'g17', 'g19', 'g23', 'g4', 'g8'],
+        'a4': ['g18', 'g20', 'g24', 'g3', 'g9'],
+    }
+
+
+def test_algorithm1_all_goods_allocated():
+    """Every good appears in exactly one bundle (no omissions, no duplicates)."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        # Generate a fresh random instance for each iteration using a deterministic seed,
+        # so failures are reproducible.
+        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
+            num_agents=4, num_items=20, num_categories=3, seed=i * 7
+        )
+        # Collect the ground-truth list of all goods across all categories.
+        all_goods = [g for items in item_categories.values() for g in items]
+        instance = Instance(valuations=valuations)
+        result = divide(
+            algorithm=fair_division_under_cardinality_constraints,
+            instance=instance,
+            item_categories=item_categories,
+            category_capacities=category_capacities,
+            initial_agent_order=agent_order,
+        )
+        # Flatten all bundles into one list and sort both sides before comparing,
+        # so the check is order-independent.
+        allocated = sorted([g for bundle in result.values() for g in bundle])
+        assert allocated == sorted(all_goods), (
+            f"Seed {i * 7}: allocated goods {allocated} != all goods {sorted(all_goods)}"
+        )
+
+
+def test_algorithm1_cardinality_constraints():
+    """No agent receives more than k_h goods from any category."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
+            num_agents=3, num_items=15, num_categories=2, seed=i * 13
+        )
+        instance = Instance(valuations=valuations)
+        result = divide(
+            algorithm=fair_division_under_cardinality_constraints,
+            instance=instance,
+            item_categories=item_categories,
+            category_capacities=category_capacities,
+            initial_agent_order=agent_order,
+        )
+        # check_cardinality_constraints verifies that for every agent and every category h,
+        # the number of goods from h in the agent's bundle does not exceed k_h.
+        assert check_cardinality_constraints(result, item_categories, category_capacities), (
+            f"Seed {i * 13}: cardinality constraint violated. result={result}"
+        )
+
+
+def test_algorithm1_ef1():
+    """The algorithm guarantees EF1 (Biswas & Barman 2018, Theorem 1)."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
+            num_agents=4, num_items=20, num_categories=3, seed=i * 17
+        )
+        instance = Instance(valuations=valuations)
+        result = divide(
+            algorithm=fair_division_under_cardinality_constraints,
+            instance=instance,
+            item_categories=item_categories,
+            category_capacities=category_capacities,
+            initial_agent_order=agent_order,
+        )
+        # check_ef1 verifies that for every pair (i, j), removing the good i values most
+        # from j's bundle eliminates i's envy — the EF1 guarantee from the paper.
+        # We include the valuations dict so check_ef1 can look up values by agent and good name.
+        assert check_ef1(result, valuations), (
+            f"Seed {i * 17}: EF1 violated. valuations={valuations}, result={result}"
+        )
+
+
+def test_algorithm1_default_order():
+    """Passing initial_agent_order=None defaults to sorted(agents), giving the same result."""
+    valuations = {
+        'Agent1': {'m1': 9, 'm2': 3, 'm3': 8, 'm4': 2},
+        'Agent2': {'m1': 3, 'm2': 9, 'm3': 2, 'm4': 8},
+    }
+    instance = Instance(valuations=valuations)
+    item_categories = {'c1': ['m1', 'm2'], 'c2': ['m3', 'm4']}
+    category_capacities = {'c1': 1, 'c2': 1}
+
+    result_none = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=instance,
+        item_categories=item_categories,
+        category_capacities=category_capacities,
+        initial_agent_order=None,
+    )
+    result_sorted = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=instance,
+        item_categories=item_categories,
+        category_capacities=category_capacities,
+        initial_agent_order=sorted(valuations.keys()),
+    )
+    assert result_none == result_sorted
+
+
+def test_algorithm1_topo_order_influences_next_category():
+    """
+    Example 9: after C1, a2 envies a1 (envy graph: a2→a1).
+    Topo sort gives σ = ['a2', 'a1'] for C2, so a2 picks first in C2.
+    a2 values C2 goods as: g4=3, g5=9, g6=6 → picks g5 (value 9) first.
+    Verify a2's C2 allocation contains g5, proving topo sort influenced picking order.
+    """
+    valuations = {
+        'a1': {'g1': 9, 'g2': 6, 'g3': 3, 'g4': 8, 'g5': 5, 'g6': 2},
+        'a2': {'g1': 4, 'g2': 7, 'g3': 8, 'g4': 3, 'g5': 9, 'g6': 6},
+    }
+    instance = Instance(valuations=valuations)
+    result = divide(
+        algorithm=fair_division_under_cardinality_constraints,
+        instance=instance,
+        item_categories={'C1': ['g1', 'g2', 'g3'], 'C2': ['g4', 'g5', 'g6']},
+        category_capacities={'C1': 2, 'C2': 2},
+        initial_agent_order=['a1', 'a2'],
+    )
+    # a2 picked first in C2 (due to topo sort) → a2 must have g5 (a2's top C2 good, value 9)
+    assert 'g5' in result['a2'], (
+        f"Expected a2 to get g5 (top C2 good) since a2 envies a1 after C1 → picks first in C2. "
+        f"Got: a2={result['a2']}"
+    )
+    # a1 should have gotten its best remaining C2 good: g4 (value 8) after a2 took g5
+    assert 'g4' in result['a1'], (
+        f"Expected a1 to get g4 after a2 took g5. Got: a1={result['a1']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 2: greedy_round_robin (Algorithm 2)
+# ---------------------------------------------------------------------------
+
+def test_greedy_picks_top_good():
+    """Each agent greedily picks their personal highest-valued good."""
+    valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 8}}
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    greedy_round_robin(alloc, ['m1', 'm2'], ['Alice', 'Bob'], {'c1': 1}, 'c1')
+    assert alloc.sorted() == {'Alice': ['m1'], 'Bob': ['m2']}
+
+
+def test_greedy_multiple_rounds():
+    """k_h=2: each agent makes 2 picks across 2 rounds."""
+    valuations = {
+        'Alice': {'m1': 10, 'm2': 8, 'm3': 5, 'm4': 3},
+        'Bob':   {'m1': 3,  'm2': 5, 'm3': 8, 'm4': 10},
+    }
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    greedy_round_robin(alloc, ['m1', 'm2', 'm3', 'm4'], ['Alice', 'Bob'], {'c1': 2}, 'c1')
+    assert alloc.sorted() == {'Alice': ['m1', 'm2'], 'Bob': ['m3', 'm4']}
+
+
+def test_greedy_partial_rounds():
+    """More agents than goods: only the first agents in order receive goods."""
+    valuations = {
+        'A': {'g1': 5, 'g2': 3},
+        'B': {'g1': 3, 'g2': 5},
+        'C': {'g1': 4, 'g2': 4},
+    }
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    # Only 2 goods, 3 agents, k_h=1 → only first 2 agents in order get a good
+    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B', 'C'], {'c1': 1}, 'c1')
+    sorted_result = alloc.sorted()
+    # Both g1 and g2 must be allocated
+    allocated = [g for bundle in sorted_result.values() for g in bundle]
+    assert sorted(allocated) == ['g1', 'g2']
+    # C (third in order) should get nothing
+    assert sorted_result['C'] == []
+
+
+def test_greedy_all_goods_allocated():
+    """Every good in the category ends up in exactly one agent's bundle."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        rng = np.random.default_rng(i * 5)
+        n, m = 3, 9
+        agents = [f"a{j}" for j in range(1, n + 1)]
+        goods = [f"g{j}" for j in range(1, m + 1)]
+        valuations = {a: {g: int(rng.integers(1, 15)) for g in goods} for a in agents}
+        k_h = math.ceil(m / n)
+        instance = Instance(valuations=valuations)
+        alloc = AllocationBuilder(instance)
+        greedy_round_robin(alloc, goods, agents, {'c1': k_h}, 'c1')
+        allocated = sorted([g for bundle in alloc.bundles.values() for g in bundle])
+        assert allocated == sorted(goods), f"Seed {i * 5}: not all goods allocated"
+
+
+def test_greedy_respects_order():
+    """
+    The agent first in agent_order gets the globally most-valued good (if they value it highest).
+    Reversing the order changes who gets the top good.
+    """
+    valuations = {'A': {'x': 10, 'y': 1}, 'B': {'x': 10, 'y': 1}}
+    # Both value x=10 equally; whoever is first gets x.
+    instance = Instance(valuations=valuations)
+
+    alloc1 = AllocationBuilder(instance)
+    greedy_round_robin(alloc1, ['x', 'y'], ['A', 'B'], {'c1': 1}, 'c1')
+    assert 'x' in alloc1.bundles['A']  # A is first, gets x
+
+    alloc2 = AllocationBuilder(instance)
+    greedy_round_robin(alloc2, ['x', 'y'], ['B', 'A'], {'c1': 1}, 'c1')
+    assert 'x' in alloc2.bundles['B']  # B is first, gets x
+
+
+def test_greedy_tied_valuations():
+    """Tied valuations must not crash; both goods must be allocated."""
+    valuations = {'A': {'g1': 5, 'g2': 5}, 'B': {'g1': 5, 'g2': 5}}
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    greedy_round_robin(alloc, ['g1', 'g2'], ['A', 'B'], {'c1': 1}, 'c1')
+    allocated = sorted([g for bundle in alloc.bundles.values() for g in bundle])
+    assert allocated == ['g1', 'g2']
+
+
+# ---------------------------------------------------------------------------
+# Section 3: eliminate_envy_cycles
+# ---------------------------------------------------------------------------
+
+def test_eliminate_no_cycle():
+    """No envy: graph is already a DAG, bundles are unchanged."""
+    valuations = {'Alice': {'m1': 9, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 9}}
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    alloc.give('Alice', 'm1')
+    alloc.give('Bob', 'm2')
+    G = eliminate_envy_cycles(alloc)
+    assert list(nz.simple_cycles(G)) == []
+    assert sorted(alloc.bundles['Alice']) == ['m1']
+    assert sorted(alloc.bundles['Bob']) == ['m2']
+
+
+def test_eliminate_2agent_cycle():
+    """2-agent mutual envy cycle: bundles are swapped."""
+    valuations = {'Alice': {'m1': 3, 'm2': 7}, 'Bob': {'m1': 7, 'm2': 3}}
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    alloc.give('Alice', 'm1')
+    alloc.give('Bob', 'm2')
+    G = eliminate_envy_cycles(alloc)
+    assert list(nz.simple_cycles(G)) == []
+    assert sorted(alloc.bundles['Alice']) == ['m2']
+    assert sorted(alloc.bundles['Bob']) == ['m1']
+
+
+def test_eliminate_3agent_cycle():
+    """3-agent cycle: bundle rotation resolves all envy."""
+    valuations = {
+        'A': {'m1': 3, 'm2': 5, 'm3': 1},
+        'B': {'m1': 1, 'm2': 3, 'm3': 5},
+        'C': {'m1': 5, 'm2': 1, 'm3': 3},
+    }
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    alloc.give('A', 'm1')
+    alloc.give('B', 'm2')
+    alloc.give('C', 'm3')
+    G = eliminate_envy_cycles(alloc)
+    assert list(nz.simple_cycles(G)) == []
+    assert sorted(alloc.bundles['A']) == ['m2']
+    assert sorted(alloc.bundles['B']) == ['m3']
+    assert sorted(alloc.bundles['C']) == ['m1']
+
+
+def test_eliminate_result_is_dag():
+    """After eliminate_envy_cycles, the returned graph always has no directed cycles."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        rng = np.random.default_rng(i * 3)
+        n, m = 4, 8
+        agents = [f"a{j}" for j in range(1, n + 1)]
+        goods = [f"g{j}" for j in range(1, m + 1)]
+        valuations = {a: {g: int(rng.integers(0, 15)) for g in goods} for a in agents}
+        instance = Instance(valuations=valuations)
+        alloc = AllocationBuilder(instance)
+        # Assign goods randomly to agents
+        shuffled = list(goods)
+        rng.shuffle(shuffled)
+        for idx, good in enumerate(shuffled):
+            alloc.give(agents[idx % n], good)
+        G = eliminate_envy_cycles(alloc)
+        assert list(nz.simple_cycles(G)) == [], f"Seed {i * 3}: cycle found in result graph"
+
+
+def test_eliminate_no_value_decrease():
+    """Lemma 1: after cycle elimination, no agent's total valuation decreases."""
+    for i in range(NUM_OF_RANDOM_INSTANCES):
+        rng = np.random.default_rng(i * 11)
+        n, m = 4, 8
+        agents = [f"a{j}" for j in range(1, n + 1)]
+        goods = [f"g{j}" for j in range(1, m + 1)]
+        valuations = {a: {g: int(rng.integers(0, 15)) for g in goods} for a in agents}
+        instance = Instance(valuations=valuations)
+        alloc = AllocationBuilder(instance)
+        shuffled = list(goods)
+        rng.shuffle(shuffled)
+        for idx, good in enumerate(shuffled):
+            alloc.give(agents[idx % n], good)
+        # Record values before
+        value_before = {
+            a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
+            for a in agents
+        }
+        eliminate_envy_cycles(alloc)
+        value_after = {
+            a: sum(instance.agent_item_value(a, g) for g in alloc.bundles[a])
+            for a in agents
+        }
+        for a in agents:
+            assert value_after[a] >= value_before[a], (
+                f"Seed {i * 11}: agent {a} value decreased from {value_before[a]} to {value_after[a]}"
+            )
+
+
+def test_eliminate_complex_overlapping():
+    """
+    Example 10 (after C2, before final cycle elimination):
+    Initial bundles: a1=[g2,g5], a2=[g1,g6], a3=[g3,g4].
+    Envy edges: a1→a2, a2→a1, a2→a3, a3→a1 (two overlapping cycles).
+    After elimination, result must be a DAG with the final EF1 bundles.
+    """
+    valuations = {
+        'a1': {'g1': 9, 'g2': 2, 'g3': 1, 'g4': 1, 'g5': 10, 'g6': 0},
+        'a2': {'g1': 10, 'g2': 8, 'g3': 1, 'g4': 10, 'g5': 1, 'g6': 0},
+        'a3': {'g1': 10, 'g2': 9, 'g3': 5, 'g4': 8, 'g5': 1, 'g6': 7},
+    }
+    instance = Instance(valuations=valuations)
+    alloc = AllocationBuilder(instance)
+    # Set up bundles directly to mirror the state after C2 round-robin
+    for g in ['g2', 'g5']:
+        alloc.give('a1', g)
+    for g in ['g1', 'g6']:
+        alloc.give('a2', g)
+    for g in ['g3', 'g4']:
+        alloc.give('a3', g)
+    G = eliminate_envy_cycles(alloc)
+    assert list(nz.simple_cycles(G)) == []
+    # Both valid elimination paths lead to the same allocation
+    assert sorted(alloc.bundles['a1']) == ['g2', 'g5']
+    assert sorted(alloc.bundles['a2']) == ['g3', 'g4']
+    assert sorted(alloc.bundles['a3']) == ['g1', 'g6']
+
+
+# ---------------------------------------------------------------------------
+# Section 4: validate_fair_division_inputs
+# ---------------------------------------------------------------------------
+
+def _make_alloc(valuations):
+    """Helper: construct an AllocationBuilder from a valuations dict."""
+    return AllocationBuilder(Instance(valuations=valuations))
+
+
+def test_validate_valid_inputs():
+    """Valid inputs do not raise any exception."""
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    validate_fair_division_inputs(
+        alloc,
+        item_categories={'c1': ['m1', 'm2']},
+        category_capacities={'c1': 1},
+        initial_agent_order=['Alice', 'Bob'],
+    )  # must not raise
+
+
+def test_validate_boundary_k_h():
+    """k_h == ceil(|C_h| / n) is the minimum valid threshold — must not raise."""
+    # 3 goods, 2 agents → k_h >= ceil(3/2) = 2
+    alloc = _make_alloc({
+        'Alice': {'m1': 5, 'm2': 3, 'm3': 1},
+        'Bob':   {'m1': 1, 'm2': 3, 'm3': 5},
+    })
+    validate_fair_division_inputs(
+        alloc,
+        item_categories={'c1': ['m1', 'm2', 'm3']},
+        category_capacities={'c1': 2},  # exactly ceil(3/2)
+        initial_agent_order=['Alice', 'Bob'],
+    )  # must not raise
+
+
+def test_validate_empty_order():
+    """Empty initial_agent_order while instance has agents → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5}, 'Bob': {'m1': 3}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, [])
+
+
+def test_validate_duplicate_in_order():
+    """Duplicate agent in initial_agent_order → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5}, 'Bob': {'m1': 3}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, ['Alice', 'Alice'])
+
+
+def test_validate_item_in_two_categories():
+    """Same item listed in two categories → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1', 'm2'], 'c2': ['m1']},
+            {'c1': 1, 'c2': 1},
+            ['Alice', 'Bob'],
+        )
+
+
+def test_validate_item_missing_from_categories():
+    """Item in valuations but absent from all categories → ValueError."""
+    # alloc has m1 and m2 in instance, but categories only cover m1
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['m1']}, {'c1': 1}, ['Alice', 'Bob'])
+
+
+def test_validate_missing_threshold():
+    """Category in item_categories has no entry in category_capacities → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1'], 'c2': ['m2']},
+            {'c1': 1},           # missing 'c2'
+            ['Alice', 'Bob'],
+        )
+
+
+def test_validate_extra_threshold():
+    """Key in category_capacities with no matching category in item_categories → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1', 'm2']},
+            {'c1': 1, 'c99': 2},  # 'c99' not in item_categories
+            ['Alice', 'Bob'],
+        )
+
+
+def test_validate_k_h_zero():
+    """k_h = 0 is not a positive integer → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': 5, 'm2': 3}, 'Bob': {'m1': 3, 'm2': 7}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(alloc, {'c1': ['m1', 'm2']}, {'c1': 0}, ['Alice', 'Bob'])
+
+
+def test_validate_k_h_too_small():
+    """k_h < ceil(|C_h| / n) violates the feasibility condition → ValueError."""
+    # 3 goods, 2 agents → k_h must be >= ceil(3/2) = 2; k_h=1 is too small
+    alloc = _make_alloc({
+        'Alice': {'m1': 5, 'm2': 3, 'm3': 1},
+        'Bob':   {'m1': 1, 'm2': 3, 'm3': 5},
+    })
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1', 'm2', 'm3']},
+            {'c1': 1},
+            ['Alice', 'Bob'],
+        )
+
+
+def test_validate_negative_valuation():
+    """Negative valuation value → ValueError."""
+    alloc = _make_alloc({'Alice': {'m1': -1, 'm2': 3}, 'Bob': {'m1': 4, 'm2': 6}})
+    with pytest.raises(ValueError):
+        validate_fair_division_inputs(
+            alloc,
+            {'c1': ['m1', 'm2']},
+            {'c1': 1},
+            ['Alice', 'Bob'],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Large random integration tests (Algorithm 1, varying sizes)
+# ---------------------------------------------------------------------------
+
+def test_random_integration_small():
+    """3-5 agents, 10-20 goods, 2-4 categories: EF1 and cardinality must hold."""
+    configs = [
+        (3, 12, 2, 101),
+        (4, 16, 3, 202),
+        (5, 20, 4, 303),
+        (3, 10, 2, 404),
+        (4, 15, 3, 505),
+    ]
+    for num_agents, num_items, num_categories, seed in configs:
+        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
+            num_agents, num_items, num_categories, seed
+        )
+        instance = Instance(valuations=valuations)
+        result = divide(
+            algorithm=fair_division_under_cardinality_constraints,
+            instance=instance,
+            item_categories=item_categories,
+            category_capacities=category_capacities,
+            initial_agent_order=agent_order,
+        )
+        assert check_cardinality_constraints(result, item_categories, category_capacities), (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): cardinality violated"
+        )
+        assert check_ef1(result, valuations), (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): EF1 violated"
+        )
+
+
+def test_random_integration_large():
+    """6-8 agents, 30-50 goods, 4-6 categories: EF1 and cardinality must hold."""
+    configs = [
+        (6, 30, 4, 1001),
+        (7, 35, 5, 2002),
+        (8, 50, 6, 3003),
+    ]
+    for num_agents, num_items, num_categories, seed in configs:
+        valuations, item_categories, category_capacities, agent_order = random_valid_instance(
+            num_agents, num_items, num_categories, seed
+        )
+        instance = Instance(valuations=valuations)
+        result = divide(
+            algorithm=fair_division_under_cardinality_constraints,
+            instance=instance,
+            item_categories=item_categories,
+            category_capacities=category_capacities,
+            initial_agent_order=agent_order,
+        )
+        assert check_cardinality_constraints(result, item_categories, category_capacities), (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): cardinality violated"
+        )
+        assert check_ef1(result, valuations), (
+            f"Config ({num_agents},{num_items},{num_categories},seed={seed}): EF1 violated"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
Implementation of Algorithms 1 & 2 from "Fair Division Under Cardinality Constraints" (Biswas & Barman, 2018, https://arxiv.org/abs/1804.09521).
 
Computes a feasible EF1 allocation when items are partitioned into categories with per-category capacity limits, using greedy round-robin per category combined with envy-cycle elimination.
 
**Files added:**
- `fairpyx/algorithms/fair_division_under_cardinality_constraints.py`
- `tests/test_fair_division_under_cardinality_constraints.py`
- Updated `fairpyx/algorithms/__init__.py`
All tests related to this algorithm pass.